### PR TITLE
CIV-6605 -  Add missing empty string to method for demo

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -90,7 +90,7 @@ withPipeline(type, product, component) {
       def subscription = 'nonprod'
       withSubscription(subscription) {
         withTeamSecrets(pipelineConf, 'demo') {
-          uploadDmnDiagrams('demo')
+          uploadDmnDiagrams('demo','')
         }
       }
     }
@@ -147,7 +147,7 @@ withPipeline(type, product, component) {
   }
 
   afterSuccess('functionalTest:aat') {
-    //Cannot upload to prod untill WA release -- uploadDmnDiagrams('prod')
+    //Cannot upload to prod untill WA release -- uploadDmnDiagrams('prod', '')
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'test-results/functional/**/*'
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
CIV-6605


### Change description ###
Add missing empty string to the demo and prod call as  missing compared to aat and preview.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
