### PR TITLE
Bug/civ 6773

### DIFF
--- a/src/main/resources/wa-task-initiation-civil-civil.dmn
+++ b/src/main/resources/wa-task-initiation-civil-civil.dmn
@@ -2481,6 +2481,130 @@ else
           <text>"standardDirectionsOrder"</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_0hdjfv2">
+        <inputEntry id="UnaryTests_0x9ol6v">
+          <text>"CLAIMANT_RESPONSE_SPEC"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1sem3qa">
+          <text>"JUDICIAL_REFERRAL"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1cxc1x2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_023wcz6">
+          <text>&gt; 1000</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1afgubj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0775nls">
+          <text>"SMALL_CLAIM"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jgzspq">
+          <text>"ONE_V_TWO_TWO_LEGAL_REP"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zoixr8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17hjq9h">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0cm5zm0">
+          <text>"FULL_DEFENCE"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bruakv">
+          <text>"FULL_DEFENCE"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1v6tong">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0i9t6a0">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0sehj0s">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1cpl5gy">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0cho6sg">
+          <text>"SmallClaimsTrackDirections"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0337o5k">
+          <text>"Small Claims Track Directions"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_102bfsv">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0yq90lr">
+          <text>5</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1igsai8">
+          <text>"standardDirectionsOrder"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_09yx7kk">
+        <inputEntry id="UnaryTests_11638e8">
+          <text>"CLAIMANT_RESPONSE_SPEC"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16m67v6">
+          <text>"JUDICIAL_REFERRAL"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pk1zfh">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0r2317c">
+          <text>&gt; 1000</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1r3x6ek">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1sd3aow">
+          <text>"SMALL_CLAIM"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11e1xzv">
+          <text>"ONE_V_TWO_TWO_LEGAL_REP"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_108hb1n">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0cnol86">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jmk2xi">
+          <text>"FULL_DEFENCE"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1p4qt7u">
+          <text>"FULL_DEFENCE"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1sg2uzq">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vy1jau">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qugfyp">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1lxsset">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_12pf8kg">
+          <text>"SmallClaimsTrackDirections"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1yr2q8z">
+          <text>"Small Claims Track Directions"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1h42n0v">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1luzeaj">
+          <text>5</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_06l28ul">
+          <text>"standardDirectionsOrder"</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_0se61u5">
         <inputEntry id="UnaryTests_0l1v76a">
           <text>"CLAIMANT_RESPONSE_SPEC"</text>

--- a/src/main/resources/wa-task-initiation-civil-civil.dmn
+++ b/src/main/resources/wa-task-initiation-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.5.1">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.1.0">
   <decision id="wa-task-initiation-civil-civil" name="Task initiation DMN">
     <decisionTable id="DecisionTable_0jtevuc" hitPolicy="COLLECT" biodi:annotationsWidth="400">
       <input id="Input_1" label="Event Id" biodi:width="319" camunda:inputVariable="eventId">
@@ -2478,6 +2478,68 @@ else
           <text>5</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0wwcc6k">
+          <text>"standardDirectionsOrder"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0se61u5">
+        <inputEntry id="UnaryTests_0l1v76a">
+          <text>"CLAIMANT_RESPONSE_SPEC"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0yawpvw">
+          <text>"JUDICIAL_REFERRAL"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17tuon9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mp169u">
+          <text>&gt; 1000</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xmnpeh">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qff7p9">
+          <text>"SMALL_CLAIM"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ohk8b4">
+          <text>"ONE_V_TWO_TWO_LEGAL_REP"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1y6zxu0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lqpt78">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1naa2al">
+          <text>"FULL_DEFENCE"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_00f5neg">
+          <text>"FULL_DEFENCE"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1aof8f2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13qxju4">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13vzphm">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0nsfbbi">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tpj89i">
+          <text>"SmallClaimsTrackDirections"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0rlktis">
+          <text>"Small Claims Track Directions"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ma7gnh">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1jm1hw1">
+          <text>5</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0smyugc">
           <text>"standardDirectionsOrder"</text>
         </outputEntry>
       </rule>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
@@ -68,6 +68,6 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
     void if_this_test_fails_needs_updating_with_your_changes() {
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(69));
+        assertThat(logic.getRules().size(), is(72));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-6773

### Change description ###
Added rules for ONE_V_TWO_TWO_LEGAL_REP scenarios in small claims, where at least Solicitor 2 or applicant disagrees with mediation, but solicitor 1 comes up as 'null'. 

Lines 38-40:
![image](https://user-images.githubusercontent.com/107135537/212327323-715ce616-90e8-4444-90b4-8b79985fde45.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
