### PR TITLE
CIV-6644 Cleanup of helm release regardless

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -60,7 +60,7 @@ withPipeline(type, product, component) {
   onPR {
     env.ENVIRONMENT = "preview"
     loadVaultSecrets(secrets)
-    enableCleanupOfHelmReleaseOnSuccess()
+    enableCleanupOfHelmReleaseAlways()
     env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
   }
   onMaster {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,7 @@
 #!groovy
 
 @Library('Infrastructure')
+import uk.gov.hmcts.contino.GithubAPI
 
 def type = "java"
 def component = "task-configuration"
@@ -54,13 +55,19 @@ def uploadDmnDiagrams(String env, String changeID) {
   }
 }
 
+def checkForEnableHelmLabel(branch_name) {
+  return new GithubAPI(this).getLabelsbyPattern(branch_name, "enableHelm").contains("enableHelm")
+}
+
 withPipeline(type, product, component) {
   pipelineConf = config
 
   onPR {
     env.ENVIRONMENT = "preview"
     loadVaultSecrets(secrets)
-    enableCleanupOfHelmReleaseAlways()
+    if (!checkForEnableHelmLabel(env.BRANCH_NAME)) {
+      enableCleanupOfHelmReleaseAlways()
+    }
     env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
   }
   onMaster {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.12.RELEASE'
   id 'org.springframework.boot' version '2.5.14'
   id 'com.github.ben-manes.versions' version '0.42.0'
-  id 'org.owasp.dependencycheck' version '7.1.1'
+  id 'org.owasp.dependencycheck' version '8.0.2'
   id 'org.sonarqube' version '3.4.0.2513'
   id 'info.solidsoft.pitest' version '1.5.2'
   id 'io.freefair.lombok' version '5.3.3.3'


### PR DESCRIPTION
### JIRA link (if applicable) ###
CIV-6644


### Change description ###
Cleanup of helm releases associated with our PRs regardless of their success or failure.
Adds support for the "enableHelm" label to keep the pods running.


This PR is aimed at continuing the work towards solving a problem we have were we often exceed our CPU/pods quota and therefore our builds start failing.
After this PR has merged, failing builds on this repository will result in the pods being deleted regardless (the logs are saved in Jenkins anyway under "Artifacts"). To compensate for this deletion for specific corner cases, support for the "enableHelm" label has been introduced like in other civil projects.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
