### PR TITLE
CIV-8143 Legal Advisor needs to be able to refer to Judge

### DIFF
--- a/src/main/resources/wa-task-completion-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-completion-civil-generalapplication.dmn
@@ -51,7 +51,7 @@
       <rule id="DecisionRule_15s2dpi">
         <description>Event that is completed by the user in ExUI. Values can be listed as comma separated</description>
         <inputEntry id="UnaryTests_1pv1bm9">
-          <text>"MAKE_DECISION"</text>
+          <text>"MAKE_DECISION","REFER_TO_JUDGE"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0uy9dr4">
           <text>"LegalAdvisorDecideOnApplication"</text>
@@ -75,7 +75,7 @@
       <rule id="DecisionRule_16fdtra">
         <description>Event that is completed by the user in ExUI. Values can be listed as comma separated</description>
         <inputEntry id="UnaryTests_1jl7uqu">
-          <text>"MAKE_DECISION"</text>
+          <text>"MAKE_DECISION","REFER_TO_JUDGE"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_042afcg">
           <text>"LegalAdvisorRevisitApplication"</text>

--- a/src/main/resources/wa-task-configuration-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-configuration-civil-generalapplication.dmn
@@ -650,7 +650,7 @@ else ""</text>
           <text>"dueDateNonWorkingCalendar"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_17tzbj7">
-          <text>"https://www.gov.uk/bank-holidays/england-and-wales.json, https://raw.githubusercontent.com/hmcts/civil-wa-task-configuration/feat/CIV-5800-fine-grained-permissions/src/main/resources/privilege-calendar.json"</text>
+          <text>"https://www.gov.uk/bank-holidays/england-and-wales.json, https://raw.githubusercontent.com/hmcts/civil-wa-task-configuration/master/src/main/resources/privilege-calendar.json"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_12l04ly">
           <text>false</text>

--- a/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="Definitions_0wgjriw" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="Definitions_0wgjriw" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.5.1">
   <decision id="wa-task-initiation-civil-generalapplication" name="Civil GA Task initiation DMN">
     <decisionTable id="DecisionTable_141h4ty" hitPolicy="COLLECT">
       <input id="Input_1" label="Event Id" camunda:inputVariable="eventId">
@@ -1763,6 +1763,286 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1hlkidb">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0jkl75n">
+        <inputEntry id="UnaryTests_12jl8li">
+          <text>"REFER_TO_JUDGE"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0f2kqfv">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hcsnyr">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bajukt">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qj6ncz">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06sicy7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1iftqfa">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tmesym">
+          <text>"JudgeDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1mxozwi">
+          <text>"Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1egpn4y">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_11vlk99">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_01mrjwm">
+        <inputEntry id="UnaryTests_1m5up2k">
+          <text>"REFER_TO_JUDGE"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ovasw3">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_07v79jh">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0p9efwc">
+          <text>true </text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0iywhvk">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ku1jwk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0htkvx8">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_12puein">
+          <text>"JudgeDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1e15x1r">
+          <text>"Application for multiple types"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0wahol4">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0z900af">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1duqmo6">
+        <inputEntry id="UnaryTests_04ul1jt">
+          <text>"REFER_TO_JUDGE"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1gw9keo">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1k7v2gn">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0s86s2i">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0mwo4q9">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vdvsgi">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ppe1cb">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1az2k75">
+          <text>"JudgeDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0cm66di">
+          <text>"Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1y4lj35">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0jmfop7">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0a8tgms">
+        <inputEntry id="UnaryTests_14phuyc">
+          <text>"REFER_TO_JUDGE"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pvwdk3">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0guq8ea">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0a1pgpl">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1htizz7">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ojzjfd">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fxpbfx">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1nynzrd">
+          <text>"JudgeDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1iurze5">
+          <text>"Application for multiple types"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0k1vuqi">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_14mfnsn">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_139imlu">
+        <inputEntry id="UnaryTests_1ur67p3">
+          <text>"REFER_TO_JUDGE"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1eprxxp">
+          <text>"ADDITIONAL_RESPONSE_TIME_EXPIRED"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ep38t3">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0o28r5z">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1h8ble1">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0v4gy48">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_047dh4k">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1re6kjk">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1narzzx">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_19i29oz">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0jbuu3z">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_06x1su2">
+        <inputEntry id="UnaryTests_0k7yneh">
+          <text>"REFER_TO_JUDGE"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ponk4m">
+          <text>"ADDITIONAL_RESPONSE_TIME_EXPIRED"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_143uzxb">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1f1yewn">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01xz5nz">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15g9nlf">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06ddayl">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0jk8ych">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_05cwaxf">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ubyqr7">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1y3xm8u">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_188znm7">
+        <inputEntry id="UnaryTests_1dagevz">
+          <text>"REFER_TO_JUDGE"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_074k44x">
+          <text>"ADDITIONAL_RESPONSE_TIME_EXPIRED"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1y1at89">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_02twql5">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_098okmu">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_035h8ek">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fg5p6j">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0ur34qp">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_14cwvar">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0mayule">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_015uing">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1sup7z8">
+        <inputEntry id="UnaryTests_0864v7l">
+          <text>"REFER_TO_JUDGE"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0frvrzy">
+          <text>"ADDITIONAL_RESPONSE_TIME_EXPIRED"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pzk7ei">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04qpzjm">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1y3gre6">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18gh7r6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pxjlv8">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0xrhqim">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0zg5wrp">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ykycy2">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_03c93o4">
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>

--- a/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
@@ -893,7 +893,7 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
       </rule>
       <rule id="DecisionRule_1aoortf">
         <inputEntry id="UnaryTests_03awqgl">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1gaqlxp">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -923,12 +923,12 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0rfhopv">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0n371xx">
         <inputEntry id="UnaryTests_15syb8q">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0rbr0i9">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -958,12 +958,12 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_001ncrx">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1502jbn">
         <inputEntry id="UnaryTests_05ixcd6">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1m2y5ki">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -993,12 +993,12 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0562dm9">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0zdezfb">
         <inputEntry id="UnaryTests_1m1qxfg">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_11803rc">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -1028,7 +1028,7 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0quqdhw">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_13nqpkk">
@@ -1063,7 +1063,7 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_01joc30">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_08d4pu7">
@@ -1098,7 +1098,7 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1vd8cw7">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0vxtnvr">
@@ -1133,7 +1133,7 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1ug5r4h">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1ddxygp">
@@ -1168,12 +1168,12 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_11gfj1y">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_10sn9xe">
         <inputEntry id="UnaryTests_0e1klgx">
-          <text>"CHANGE_STATE_TO_ADDITIONAL_RESPONSE_TIME_EXPIRED","TRIGGER_LOCATION_UPDATE"</text>
+          <text>"CHANGE_STATE_TO_ADDITIONAL_RESPONSE_TIME_EXPIRED"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1o7ax7u">
           <text>"ADDITIONAL_RESPONSE_TIME_EXPIRED"</text>
@@ -1203,12 +1203,12 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1ggnm6v">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_18jr0f4">
         <inputEntry id="UnaryTests_1kslsko">
-          <text>"CHANGE_STATE_TO_ADDITIONAL_RESPONSE_TIME_EXPIRED","TRIGGER_LOCATION_UPDATE"</text>
+          <text>"CHANGE_STATE_TO_ADDITIONAL_RESPONSE_TIME_EXPIRED"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1eqw6ds">
           <text>"ADDITIONAL_RESPONSE_TIME_EXPIRED"</text>
@@ -1238,12 +1238,12 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1h5uyxj">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_09gj502">
         <inputEntry id="UnaryTests_0xi7eyx">
-          <text>"CHANGE_STATE_TO_ADDITIONAL_RESPONSE_TIME_EXPIRED","TRIGGER_LOCATION_UPDATE"</text>
+          <text>"CHANGE_STATE_TO_ADDITIONAL_RESPONSE_TIME_EXPIRED"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1gvqmzy">
           <text>"ADDITIONAL_RESPONSE_TIME_EXPIRED"</text>
@@ -1273,12 +1273,12 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1lv8ki5">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1g6ilv3">
         <inputEntry id="UnaryTests_0pjifz6">
-          <text>"CHANGE_STATE_TO_ADDITIONAL_RESPONSE_TIME_EXPIRED","TRIGGER_LOCATION_UPDATE"</text>
+          <text>"CHANGE_STATE_TO_ADDITIONAL_RESPONSE_TIME_EXPIRED"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_16ldclh">
           <text>"ADDITIONAL_RESPONSE_TIME_EXPIRED"</text>
@@ -1308,7 +1308,7 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_01zfgps">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_124xiat">

--- a/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
@@ -1798,7 +1798,7 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_11vlk99">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_01mrjwm">
@@ -1833,7 +1833,7 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0z900af">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1duqmo6">
@@ -1868,7 +1868,7 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0jmfop7">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0a8tgms">
@@ -1903,7 +1903,7 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_14mfnsn">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_139imlu">
@@ -1938,7 +1938,7 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0jbuu3z">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_06x1su2">
@@ -1973,7 +1973,7 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1y3xm8u">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_188znm7">
@@ -2008,7 +2008,7 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_015uing">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1sup7z8">
@@ -2043,7 +2043,7 @@ or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_03c93o4">
-          <text>"generalApplications"</text>
+          <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
     </decisionTable>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmnga/CamundaGaSubmissionTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmnga/CamundaGaSubmissionTaskWaInitiationTest.java
@@ -58,7 +58,7 @@ public class CamundaGaSubmissionTaskWaInitiationTest extends DmnDecisionTableBas
 
     @ParameterizedTest
     @CsvSource(value = {
-        "END_BUSINESS_PROCESS_GASPEC", "TRIGGER_LOCATION_UPDATE"
+        "END_BUSINESS_PROCESS_GASPEC"
     })
     void when_urgent_ga_creation_with_pre_sdo_refer_legalAdvisor(String eventId) {
 
@@ -150,7 +150,7 @@ public class CamundaGaSubmissionTaskWaInitiationTest extends DmnDecisionTableBas
 
     @ParameterizedTest
     @CsvSource(value = {
-        "END_BUSINESS_PROCESS_GASPEC", "TRIGGER_LOCATION_UPDATE"
+        "END_BUSINESS_PROCESS_GASPEC"
     })
 
     void when_urgent_ga_creation_with_pre_sdo_multiple_types_refer_legalAdvisor(String eventId) {
@@ -247,7 +247,7 @@ public class CamundaGaSubmissionTaskWaInitiationTest extends DmnDecisionTableBas
 
     @ParameterizedTest
     @CsvSource(value = {
-        "END_BUSINESS_PROCESS_GASPEC", "TRIGGER_LOCATION_UPDATE"
+        "END_BUSINESS_PROCESS_GASPEC"
     })
     void when_non_urgent_ga_creation_with_pre_sdo_single_application_refer_legalAdvisor(String eventId) {
 
@@ -370,7 +370,7 @@ public class CamundaGaSubmissionTaskWaInitiationTest extends DmnDecisionTableBas
 
     @ParameterizedTest
     @CsvSource(value = {
-        "END_BUSINESS_PROCESS_GASPEC", "TRIGGER_LOCATION_UPDATE"
+        "END_BUSINESS_PROCESS_GASPEC"
     })
     void when_non_urgent_ga_creation_with_pre_sdo_multiple_types_refer_legalAdvisor(String eventId) {
 
@@ -1089,7 +1089,7 @@ public class CamundaGaSubmissionTaskWaInitiationTest extends DmnDecisionTableBas
 
     @ParameterizedTest
     @CsvSource(value = {
-        "CHANGE_STATE_TO_ADDITIONAL_RESPONSE_TIME_EXPIRED", "TRIGGER_LOCATION_UPDATE"
+        "CHANGE_STATE_TO_ADDITIONAL_RESPONSE_TIME_EXPIRED"
     })
     void when_change_state_to_addln_response_time_expired_nonurgent_with_pre_sdo_refer_legalAdvisor(String eventId) {
 
@@ -1196,7 +1196,7 @@ public class CamundaGaSubmissionTaskWaInitiationTest extends DmnDecisionTableBas
 
     @ParameterizedTest
     @CsvSource(value = {
-        "CHANGE_STATE_TO_ADDITIONAL_RESPONSE_TIME_EXPIRED", "TRIGGER_LOCATION_UPDATE"
+        "CHANGE_STATE_TO_ADDITIONAL_RESPONSE_TIME_EXPIRED"
     })
     void when_change_state_to_addln_response_time_expired_nonurgent_app_with_pre_sdo_single_ga_type_refer_LegalAdvisor(
         String eventId) {
@@ -1305,7 +1305,7 @@ public class CamundaGaSubmissionTaskWaInitiationTest extends DmnDecisionTableBas
 
     @ParameterizedTest
     @CsvSource(value = {
-        "CHANGE_STATE_TO_ADDITIONAL_RESPONSE_TIME_EXPIRED", "TRIGGER_LOCATION_UPDATE"
+        "CHANGE_STATE_TO_ADDITIONAL_RESPONSE_TIME_EXPIRED"
     })
     void when_change_state_to_addln_response_time_expired_urgent_app_with_pre_sdo_refer_legalAdvisor(String eventId) {
 
@@ -1509,7 +1509,7 @@ public class CamundaGaSubmissionTaskWaInitiationTest extends DmnDecisionTableBas
 
     @ParameterizedTest
     @CsvSource(value = {
-        "CHANGE_STATE_TO_ADDITIONAL_RESPONSE_TIME_EXPIRED", "TRIGGER_LOCATION_UPDATE"
+        "CHANGE_STATE_TO_ADDITIONAL_RESPONSE_TIME_EXPIRED"
     })
     void when_taskId_then_return_decision_making_work_for_urgent_listed_for_hearing_refer_legalAdvisor(String eventId) {
 

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmnga/CamundaGaSubmissionTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmnga/CamundaGaSubmissionTaskWaInitiationTest.java
@@ -1870,4 +1870,293 @@ public class CamundaGaSubmissionTaskWaInitiationTest extends DmnDecisionTableBas
         assertThat(workTypeResultList.get(0).get("name"), is("Revisit Application for Unless Order"));
     }
 
+    @Test
+    void when_refer_to_judge_urgent_app_for_await_judicial_decision_ccmc_single_appln() {
+
+        /*if(caseData.generalAppUrgencyRequirement.generalAppUrgency != "Yes") then 2 else 5*/
+        Map<String, Object> data = new HashMap<>();
+        data.put("generalAppUrgencyRequirement", Map.of(
+            "generalAppUrgency", true
+        ));
+        data.put("isCcmccLocation", true);
+        data.put("judicialDecision", Map.of(
+            "decision", "MAKE_ORDER_FOR_WRITTEN_REPRESENTATIONS"
+        ));
+        data.put("generalAppType", Map.of(
+            "types", asList("SUMMARY_JUDGEMENT")
+        ));
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", "REFER_TO_JUDGE");
+        inputVariables.putValue("postEventState", "APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList.get(0).get("name"), is("Application for summary judgement"));
+        assertThat(workTypeResultList.get(0).get("taskId"), is("JudgeDecideOnApplication"));
+
+    }
+
+    @Test
+    void when_refer_to_judge_urgent_app_for_await_judicial_decision_multiple_appln_type() {
+
+        /*if(caseData.generalAppUrgencyRequirement.generalAppUrgency != "Yes") then 2 else 5*/
+        Map<String, Object> data = new HashMap<>();
+        data.put("generalAppUrgencyRequirement", Map.of(
+            "generalAppUrgency", true
+        ));
+        data.put("isCcmccLocation", true);
+        data.put("judicialDecision", Map.of(
+            "decision", "MAKE_ORDER_FOR_WRITTEN_REPRESENTATIONS"
+        ));
+        data.put("generalAppType", Map.of(
+            "types", asList("STRIKE_OUT", "SUMMARY_JUDGEMENT")
+        ));
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", "REFER_TO_JUDGE");
+        inputVariables.putValue("postEventState", "APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList.get(0).get("name"), is("Application for multiple types"));
+        assertThat(workTypeResultList.get(0).get("taskId"), is("JudgeDecideOnApplication"));
+    }
+
+    @Test
+    void when_refer_to_judge_non_urgent_app_for_await_judicial_decision_ccmc_single_appln() {
+
+        /*if(caseData.generalAppUrgencyRequirement.generalAppUrgency != "Yes") then 2 else 5*/
+        Map<String, Object> data = new HashMap<>();
+        data.put("generalAppUrgencyRequirement", Map.of(
+            "generalAppUrgency", false
+        ));
+        data.put("isCcmccLocation", true);
+        data.put("judicialDecision", Map.of(
+            "decision", "MAKE_ORDER_FOR_WRITTEN_REPRESENTATIONS"
+        ));
+        data.put("generalAppType", Map.of(
+            "types", asList("SUMMARY_JUDGEMENT")
+        ));
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", "REFER_TO_JUDGE");
+        inputVariables.putValue("postEventState", "APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList.get(0).get("taskId"), is("JudgeDecideOnApplication"));
+        assertThat(workTypeResultList.get(0).get("name"), is("Application for summary judgement"));
+    }
+
+    @Test
+    void when_refer_to_judge_non_urgent_app_for_await_judicial_decision_multiple_appln_type() {
+
+        /*if(caseData.generalAppUrgencyRequirement.generalAppUrgency != "Yes") then 2 else 5*/
+        Map<String, Object> data = new HashMap<>();
+        data.put("generalAppUrgencyRequirement", Map.of(
+            "generalAppUrgency", false
+        ));
+        data.put("isCcmccLocation", true);
+        data.put("judicialDecision", Map.of(
+            "decision", "MAKE_ORDER_FOR_WRITTEN_REPRESENTATIONS"
+        ));
+        data.put("generalAppType", Map.of(
+            "types", asList("STRIKE_OUT", "SUMMARY_JUDGEMENT")
+        ));
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", "REFER_TO_JUDGE");
+        inputVariables.putValue("postEventState", "APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList.get(0).get("taskId"), is("JudgeDecideOnApplication"));
+        assertThat(workTypeResultList.get(0).get("name"), is("Application for multiple types"));
+    }
+
+    @Test
+    void when_refer_to_judge_urgent_app_for_await_judicial_decision_ccmcc_location_no() {
+
+        /*if(caseData.generalAppUrgencyRequirement.generalAppUrgency != "Yes") then 2 else 5*/
+        Map<String, Object> data = new HashMap<>();
+        data.put("generalAppUrgencyRequirement", Map.of(
+            "generalAppUrgency", true
+        ));
+        data.put("isCcmccLocation", false);
+        data.put("judicialDecision", Map.of(
+            "decision", "MAKE_ORDER_FOR_WRITTEN_REPRESENTATIONS"
+        ));
+        data.put("generalAppType", Map.of(
+            "types", asList("STRIKE_OUT", "SUMMARY_JUDGEMENT")
+        ));
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", "REFER_TO_JUDGE");
+        inputVariables.putValue("postEventState", "APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(0));
+    }
+
+    @Test
+    void when_refer_to_judge_urgent_app_for_addln_response_expired_single_type() {
+
+        /*if(caseData.generalAppUrgencyRequirement.generalAppUrgency != "Yes") then 2 else 5*/
+        Map<String, Object> data = new HashMap<>();
+        data.put("generalAppUrgencyRequirement", Map.of(
+            "generalAppUrgency", true
+        ));
+        data.put("isCcmccLocation", true);
+        data.put("judicialDecision", Map.of(
+            "decision", "MAKE_ORDER_FOR_WRITTEN_REPRESENTATIONS"
+        ));
+        data.put("generalAppType", Map.of(
+            "types", asList("SUMMARY_JUDGEMENT")
+        ));
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", "REFER_TO_JUDGE");
+        inputVariables.putValue("postEventState", "ADDITIONAL_RESPONSE_TIME_EXPIRED");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList
+                       .get(0).get("name"), is("summary judgement App - "
+                                                   + "revisited make order for "
+                                                   + "written representations"));
+        assertThat(workTypeResultList.get(0).get("taskId"), is("JudgeRevisitApplication"));
+    }
+
+    @Test
+    void when_refer_to_judge_urgent_app_for_addln_response_expired_multiple_type() {
+
+        /*if(caseData.generalAppUrgencyRequirement.generalAppUrgency != "Yes") then 2 else 5*/
+        Map<String, Object> data = new HashMap<>();
+        data.put("generalAppUrgencyRequirement", Map.of(
+            "generalAppUrgency", true
+        ));
+        data.put("isCcmccLocation", true);
+        data.put("judicialDecision", Map.of(
+            "decision", "MAKE_ORDER_FOR_WRITTEN_REPRESENTATIONS"
+        ));
+        data.put("generalAppType", Map.of(
+            "types", asList("STRIKE_OUT", "SUMMARY_JUDGEMENT")
+        ));
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", "REFER_TO_JUDGE");
+        inputVariables.putValue("postEventState", "ADDITIONAL_RESPONSE_TIME_EXPIRED");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList
+                       .get(0).get("name"), is("Application for multiple types - "
+                                                   + "revisited make order for "
+                                                   + "written representations"));
+        assertThat(workTypeResultList.get(0).get("taskId"), is("JudgeRevisitApplication"));
+    }
+
+    @Test
+    void when_refer_to_judge_nonurgent_app_for_addln_response_expired_single_type() {
+
+        /*if(caseData.generalAppUrgencyRequirement.generalAppUrgency != "Yes") then 2 else 5*/
+        Map<String, Object> data = new HashMap<>();
+        data.put("generalAppUrgencyRequirement", Map.of(
+            "generalAppUrgency", false
+        ));
+        data.put("isCcmccLocation", true);
+        data.put("judicialDecision", Map.of(
+            "decision", "MAKE_ORDER_FOR_WRITTEN_REPRESENTATIONS"
+        ));
+        data.put("generalAppType", Map.of(
+            "types", asList("SUMMARY_JUDGEMENT")
+        ));
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", "REFER_TO_JUDGE");
+        inputVariables.putValue("postEventState", "ADDITIONAL_RESPONSE_TIME_EXPIRED");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList
+                       .get(0).get("name"), is("summary judgement App - "
+                                                   + "revisited make order for "
+                                                   + "written representations"));
+        assertThat(workTypeResultList.get(0).get("taskId"), is("JudgeRevisitApplication"));
+    }
+
+    @Test
+    void when_refer_to_judge_non_urgent_app_for_addln_response_expired_multiple_type() {
+
+        /*if(caseData.generalAppUrgencyRequirement.generalAppUrgency != "Yes") then 2 else 5*/
+        Map<String, Object> data = new HashMap<>();
+        data.put("generalAppUrgencyRequirement", Map.of(
+            "generalAppUrgency", false
+        ));
+        data.put("isCcmccLocation", true);
+        data.put("judicialDecision", Map.of(
+            "decision", "MAKE_ORDER_FOR_WRITTEN_REPRESENTATIONS"
+        ));
+        data.put("generalAppType", Map.of(
+            "types", asList("STRIKE_OUT", "SUMMARY_JUDGEMENT")
+        ));
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", "REFER_TO_JUDGE");
+        inputVariables.putValue("postEventState", "ADDITIONAL_RESPONSE_TIME_EXPIRED");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList
+                       .get(0).get("name"), is("Application for multiple types - "
+                                                   + "revisited make order for "
+                                                   + "written representations"));
+        assertThat(workTypeResultList.get(0).get("taskId"), is("JudgeRevisitApplication"));
+    }
 }

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmnga/CamundaGaTaskCompletion.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmnga/CamundaGaTaskCompletion.java
@@ -62,7 +62,18 @@ public class CamundaGaTaskCompletion extends DmnDecisionTableBaseUnitTest {
                         ),
                         Map.of(
                             "completionMode", "Auto"
-                        )))
+                        ))),
+            Arguments.of(
+                "REFER_TO_JUDGE",
+                asList(
+                    Map.of(
+                        "taskType", "LegalAdvisorDecideOnApplication",
+                        "completionMode", "Auto"
+                    ),
+                    Map.of(
+                           "taskType", "LegalAdvisorRevisitApplication",
+                        "completionMode", "Auto"
+                    )))
         );
     }
 


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x ] commit messages are meaningful and follow good commit message guidelines
- [x ] README and other documentation has been updated / added (if needed)
- [x ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-8143

### Change description ###

Legal Advisor needs to be able to refer to Judge

Once Legal Advisors receive a work allocation task to make a decision they are able to run an event on the application to make a decision.  They need to be able to run an event which refers the application to a Judge in the scenario where the Legal Advisor cannot make a decision.  The current requirement was that the LA would unassign the task for another LA to pick up. This will only be applicable to Pre-SDO cases

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
