### PR TITLE
CIV-7877 Default Judgment journey: ‘not suitable for SDO’ event in the next step dropdown WA changes

### DIFF
--- a/src/main/resources/wa-task-completion-civil-civil.dmn
+++ b/src/main/resources/wa-task-completion-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-completion-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.5.1">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-completion-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.4.1">
   <decision id="wa-task-completion-civil-civil" name="Civil  Task completion DMN">
     <decisionTable id="DecisionTable_01re27ma" hitPolicy="COLLECT">
       <input id="eventId" label="Event ID" biodi:width="614">
@@ -12,7 +12,7 @@
       <rule id="DecisionRule_12eentya">
         <description>Event that is completed by the user in ExUI. Values can be listed as comma separated</description>
         <inputEntry id="UnaryTests_17cg7dea">
-          <text>"STANDARD_DIRECTION_ORDER_DJ"</text>
+          <text>"STANDARD_DIRECTION_ORDER_DJ","NotSuitable_SDO"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1lk4wxea">
           <text>"summaryJudgmentDirections"</text>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskCompletionTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskCompletionTest.java
@@ -86,6 +86,10 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
                 "NotSuitable_SDO",
                 asList(
                     Map.of(
+                        "taskType", "summaryJudgmentDirections",
+                        "completionMode", "Auto"
+                    ),
+                    Map.of(
                         "taskType", "FastTrackDirections",
                         "completionMode", "Auto"
                     ),


### PR DESCRIPTION
Default Judgment journey: ‘not suitable for SDO’ event in the next step dropdown


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-7877



### Change description ###
Default Judgment journey: ‘not suitable for SDO’ event in the next step dropdown


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
