### PR TITLE
CIV-7997 Schedule hearing SDO DJ WA task update

### DIFF
--- a/src/main/resources/wa-task-completion-civil-civil.dmn
+++ b/src/main/resources/wa-task-completion-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-completion-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.1.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-completion-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-completion-civil-civil" name="Civil  Task completion DMN">
     <decisionTable id="DecisionTable_01re27ma" hitPolicy="COLLECT">
       <input id="eventId" label="Event ID" biodi:width="614">
@@ -84,7 +84,7 @@
       <rule id="DecisionRule_14v2a24">
         <description>Event that is completed by the user in ExUI. Values can be listed as comma separated</description>
         <inputEntry id="UnaryTests_06aa70b">
-          <text>"HEARING_SCHEDULED"</text>
+          <text>"ADD_CASE_NOTE"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1gd466g">
           <text>"ScheduleAHearing"</text>
@@ -96,7 +96,7 @@
       <rule id="DecisionRule_03emooj">
         <description>Left empty so event can be triggered without a task</description>
         <inputEntry id="UnaryTests_0a1yp1f">
-          <text>"HEARING_SCHEDULED"</text>
+          <text>"ADD_CASE_NOTE"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_18kljqp">
           <text></text>

--- a/src/main/resources/wa-task-configuration-civil-civil.dmn
+++ b/src/main/resources/wa-task-configuration-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.1.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-configuration-civil-civil" name="Civil Task configuration DMN">
     <decisionTable id="DecisionTable_14cx0791" hitPolicy="COLLECT">
       <input id="InputClause_1gxyo7fa" label="CCD Case Data" camunda:inputVariable="caseData">
@@ -273,7 +273,7 @@ else ""</text>
           <text>"description"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1kbvzb8">
-          <text>"[Directions - Schedule A Hearing](/cases/case-details/${[CASE_REFERENCE]}/trigger/HEARING_SCHEDULED/HEARING_SCHEDULEDHearingNoticeSelect)"</text>
+          <text>"[Schedule a hearing](/cases/case-details/${[CASE_REFERENCE]}/trigger/ADD_CASE_NOTE/ADD_CASE_NOTE)"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0tgcyng">
           <text>"true"</text>

--- a/src/main/resources/wa-task-configuration-civil-civil.dmn
+++ b/src/main/resources/wa-task-configuration-civil-civil.dmn
@@ -273,7 +273,7 @@ else ""</text>
           <text>"description"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1kbvzb8">
-          <text>"[Schedule a hearing](/cases/case-details/${[CASE_REFERENCE]}/trigger/ADD_CASE_NOTE/ADD_CASE_NOTE)"</text>
+          <text>"[Add a case note](/cases/case-details/${[CASE_REFERENCE]}/trigger/ADD_CASE_NOTE/ADD_CASE_NOTE)"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0tgcyng">
           <text>"true"</text>

--- a/src/main/resources/wa-task-configuration-civil-civil.dmn
+++ b/src/main/resources/wa-task-configuration-civil-civil.dmn
@@ -198,7 +198,7 @@ else "1"</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_00px7ye">
-          <text>"transferCaseOfflineNotSuitableSDO","ScheduleAHearing"</text>
+          <text>"transferCaseOfflineNotSuitableSDO","ScheduleAHearing","reviewSpecificAccessRequestAdmin"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1koffim">
           <text>"roleCategory"</text>
@@ -352,24 +352,6 @@ else ""</text>
           <text>"LEGAL_OPERATIONS"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_075warl">
-          <text>"true"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_05xw514">
-        <inputEntry id="UnaryTests_02o9b0n">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0byfs3s">
-          <text>"ScheduleAHearing",
-"reviewSpecificAccessRequestAdmin"</text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_0sbobgy">
-          <text>"roleCategory"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0w03jo5">
-          <text>"ADMIN"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1mq130j">
           <text>"true"</text>
         </outputEntry>
       </rule>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskCompletionTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskCompletionTest.java
@@ -103,7 +103,7 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
     static Stream<Arguments> scenarioProviderHearingNotice() {
         return Stream.of(
             Arguments.of(
-                "HEARING_SCHEDULED",
+                "ADD_CASE_NOTE",
                 asList(
                     Map.of(
                         "taskType", "ScheduleAHearing",

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
@@ -44,8 +44,7 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
     @SuppressWarnings("checkstyle:indentation")
     @ParameterizedTest
     @CsvSource(value = {
-        "NULL_VALUE, ''",
-        "'', ''"
+        "NULL_VALUE, ''", "'', ''"
     }, nullValues = "NULL_VALUE")
     void when_caseData_then_return_expected_name_and_value_rows(String appealType, String expectedAppealType) {
 

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
@@ -37,7 +37,7 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
 
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(27));
+        assertThat(logic.getRules().size(), is(26));
 
     }
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-8340

Adjusted the WA task created after SDO or DJ event is triggered to link admin to add a case note.

<img width="1566" alt="Screenshot 2023-06-07 at 21 16 09" src="https://github.com/hmcts/civil-wa-task-configuration/assets/90632240/c10b36d9-d594-44cb-87a4-af2c1f6e5c2e">

<img width="1762" alt="Screenshot 2023-06-07 at 21 19 34" src="https://github.com/hmcts/civil-wa-task-configuration/assets/90632240/f4a98c95-7585-4cd7-bf46-f8d07d06990a">

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```

