### PR TITLE
CIV-9618 GA consent order

### DIFF
--- a/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
@@ -63,7 +63,7 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputExpression>
       </input>
       <input id="InputClause_1s4wp88" label="isAlreadyReferedToJudge">
-        <inputExpression id="LiteralExpression_0xukk5x" typeRef="string">
+        <inputExpression id="LiteralExpression_0xukk5x" typeRef="boolean">
           <text>if(additionalData.Data.referToJudge!= null) then true
 else false</text>
         </inputExpression>

--- a/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
@@ -2905,7 +2905,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_070xna9">
         <inputEntry id="UnaryTests_16spx0x">
-          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","CHANGE_STATE_TO_AWAITING_JUDICIAL_DECISION"</text>
+          <text>"CHANGE_STATE_TO_AWAITING_JUDICIAL_DECISION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1rin9ur">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -2926,7 +2926,7 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1lasnoi">
-          <text></text>
+          <text>-</text>
         </inputEntry>
         <inputEntry id="UnaryTests_10nhxqs">
           <text>true</text>
@@ -2950,9 +2950,150 @@ else false</text>
           <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_0fkf1zq">
+        <inputEntry id="UnaryTests_1x09akr">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1b1qp58">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kiusul">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05y1hhx">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lhc3r4">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yxabiv">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0mrzh9s">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19spxik">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ylu7r0">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_070dcaw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vy2vm3">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tmzw1g">
+          <text>"ReviewApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0gypj4a">
+          <text> "Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0agitvd">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0vnpvta">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0qi7mo1">
+        <inputEntry id="UnaryTests_066tiix">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1wc7w81">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uz8vk4">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hpzc4l">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pirslo">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0dfwnp5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1noes7d">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1dpiu13">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0sv4xfn">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0jyvvyq">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1u88iuj">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0mszdwe">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_01fbjav">
+          <text> lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ydxgd5">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0jvcy0c">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0aqx029">
+        <inputEntry id="UnaryTests_0o4gcas">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0t5c6ls">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qy7viy">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1nxm32r">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0yqxra0">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1utfwqe">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0n08bzq">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fkg13s">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uq7bkk">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vmt085">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0bt8stl">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19zbnqx">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1j7pma0">
+          <text> lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1vsav03">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_032yb06">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_0c0oi8c">
         <inputEntry id="UnaryTests_04yvyz4">
-          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","CHANGE_STATE_TO_AWAITING_JUDICIAL_DECISION"</text>
+          <text>"CHANGE_STATE_TO_AWAITING_JUDICIAL_DECISION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1v0qxhx">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -2973,7 +3114,7 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0sgsfa4">
-          <text></text>
+          <text>-</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ur1rh5">
           <text>true</text>
@@ -2997,9 +3138,150 @@ else false</text>
           <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_0sav2df">
+        <inputEntry id="UnaryTests_09sn0g5">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vbokpe">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11la0au">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ovd7w3">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ujbijh">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1i50bvr">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13ryd1h">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vy65ac">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zz2ww5">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1l5xiui">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0slxvfz">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1007g3g">
+          <text>"ReviewApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0svqos7">
+          <text> "Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1a6whl4">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0b72p8l">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0z3g8d6">
+        <inputEntry id="UnaryTests_0bjzw9t">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_08pcaen">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15lr8ii">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hpvp8i">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10ikv7q">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1g6b9ta">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0t8hqsb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uwaylj">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0s198xl">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1f29i2y">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05z41gy">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0jl7frc">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_104lvsw">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_101tio3">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1dcphqp">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_168c020">
+        <inputEntry id="UnaryTests_1qkccyq">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0dex0vl">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1d1wauz">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0dehx40">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1w4yt4a">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0e9rlic">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0uzy6gv">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01y8abc">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1broy36">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0uxjopj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1il9ux0">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0d93t0k">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1sd6bly">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_14lf9ml">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0wuah36">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_1bajgt6">
         <inputEntry id="UnaryTests_16t3n33">
-          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","CHANGE_STATE_TO_AWAITING_JUDICIAL_DECISION"</text>
+          <text>"CHANGE_STATE_TO_AWAITING_JUDICIAL_DECISION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0hten1x">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -3020,7 +3302,7 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_10vmgyz">
-          <text></text>
+          <text>-</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0oro08q">
           <text>true</text>
@@ -3044,9 +3326,150 @@ else false</text>
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_0lskmvz">
+        <inputEntry id="UnaryTests_01bswk7">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1hr308p">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10kepw2">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mf9uo9">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1tqtfid">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0krg4u5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1j0le4z">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1waq5qg">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0bpmx54">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1gcjhs1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0yhhajk">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0zsfgic">
+          <text>"ReviewApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0d8qjiy">
+          <text>"Application for multiple types"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_19djcpe">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0kfyozj">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1wztlxz">
+        <inputEntry id="UnaryTests_068wq7u">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1icp7kz">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lac7o2">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1nh7yle">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_128hv3j">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1di3zhm">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ig4vc6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kkmhi9">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0dxj76y">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0f6sz2s">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fdpx4k">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1gtsatt">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0rm5dnq">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0s0sy07">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0rtmx6c">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0a7uwlb">
+        <inputEntry id="UnaryTests_16w749m">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0y11lod">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0o9yoce">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1x9nvoz">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1wfdu2e">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0awzsfi">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1hpyt8f">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ew7wq0">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mh8ihx">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0837rxn">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11t7y7q">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0uzal2z">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_10l2hgo">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_10ssvle">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0o2nim4">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_0zcrv86">
         <inputEntry id="UnaryTests_0n1ee0r">
-          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","CHANGE_STATE_TO_AWAITING_JUDICIAL_DECISION"</text>
+          <text>"CHANGE_STATE_TO_AWAITING_JUDICIAL_DECISION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1h8g43t">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -3067,7 +3490,7 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0lc3z7k">
-          <text></text>
+          <text>-</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0gkzm4q">
           <text>true</text>
@@ -3091,9 +3514,150 @@ else false</text>
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_005tbvq">
+        <inputEntry id="UnaryTests_0z64qim">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0rxo880">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0myjlzy">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0du1kp8">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0jkxae0">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0djftuw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0gzhlle">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ntgg53">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11vkf7e">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_158euli">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bvso2h">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_02bn8g7">
+          <text>"ReviewApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1a028zt">
+          <text>"Application for multiple types"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_11mpsvw">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_00clf7p">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_007cwae">
+        <inputEntry id="UnaryTests_08fsmgi">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zh6ei5">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12yhl1r">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1d0zain">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1few6cc">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qvtvcw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0thxuh9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_02ppvg8">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_142700k">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1casvr9">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0j0kl6e">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1mdch03">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0zay0yb">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ecuyiy">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0o4rzu2">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1o2uckt">
+        <inputEntry id="UnaryTests_1ghcqi7">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_069jfqq">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0dltnai">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17x77jv">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0yt6w8s">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wqkh2o">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mbk337">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04p58co">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mtbdwz">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0jfuseg">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1sieoex">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0xigm8x">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0f9pxb5">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0zlmody">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1b8lq5w">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_1px88nb">
         <inputEntry id="UnaryTests_1eb2t9l">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION","CHANGE_STATE_TO_AWAITING_JUDICIAL_DECISION"</text>
+          <text>"TRIGGER_LOCATION_UPDATE","CHANGE_STATE_TO_AWAITING_JUDICIAL_DECISION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0e0ffl7">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -3114,7 +3678,7 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0lggg09">
-          <text></text>
+          <text>-</text>
         </inputEntry>
         <inputEntry id="UnaryTests_021xvdp">
           <text>true</text>
@@ -3138,9 +3702,150 @@ else false</text>
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_1tf1rco">
+        <inputEntry id="UnaryTests_169b5x0">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1knau1z">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1n0vpb8">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uwo6lj">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tupcpz">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vj1j0d">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1m2axbg">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1g3lljn">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0cozpa8">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ojh39j">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0x4lhi4">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0odxurq">
+          <text>"ReviewApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_10e4df6">
+          <text> "Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1grarnk">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0hncsse">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_12m3o4x">
+        <inputEntry id="UnaryTests_0h7lbbo">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0o75mk8">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1lwncr2">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18kyoy5">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0nob4zz">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1psz4po">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mal0qm">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yq0cat">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0py4647">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1te1r94">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0f2s6fn">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0rsrvso">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1yz5hku">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_10dawag">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_14z8uf2">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0uqjujy">
+        <inputEntry id="UnaryTests_1lwr8v9">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0mvh3e9">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ca2v2k">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0nz9s8y">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0urzc0s">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12lkarn">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0yv9cah">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0rcn3ek">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19zf120">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0z8hz5b">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kmg262">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0u90tvp">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_04xpj6p">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0prt4x3">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0nq5c4s">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_09y8joc">
         <inputEntry id="UnaryTests_04y9fhn">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION","CHANGE_STATE_TO_AWAITING_JUDICIAL_DECISION"</text>
+          <text>"TRIGGER_LOCATION_UPDATE","CHANGE_STATE_TO_AWAITING_JUDICIAL_DECISION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_12z8f6i">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -3161,7 +3866,7 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ozbjmo">
-          <text></text>
+          <text>-</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1dpfvej">
           <text>true</text>
@@ -3185,9 +3890,150 @@ else false</text>
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_120i1n0">
+        <inputEntry id="UnaryTests_0g3z66p">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0f4ek7a">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uidazy">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_177bt4s">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fhw7zh">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18pbad0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0x7327k">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qdhwl6">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1r3tfuf">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qb6kte">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_058io1a">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1n3my54">
+          <text>"ReviewApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ymwpmz">
+          <text> "Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0by5vd8">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1da6p0g">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0u202ni">
+        <inputEntry id="UnaryTests_042br0h">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16903hu">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1673rej">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hl58p7">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_02sdhr4">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01fuz18">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0sfr7ks">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ynxv1g">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0riu469">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0t301zq">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03vyb1d">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1wy3l4c">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0jczcm2">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_078xil7">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0f1jvim">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_131yozd">
+        <inputEntry id="UnaryTests_1d84k22">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15753qf">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_123g9d4">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vfyhf3">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0n4z8mg">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11p6r3z">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0jhslto">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ei5xds">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1kzhpp3">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19cddax">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_02v79l8">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1trowqe">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0zop5sh">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0yo1hki">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0uw41rl">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_19zxguv">
         <inputEntry id="UnaryTests_1pgudtj">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION","CHANGE_STATE_TO_AWAITING_JUDICIAL_DECISION"</text>
+          <text>"TRIGGER_LOCATION_UPDATE","CHANGE_STATE_TO_AWAITING_JUDICIAL_DECISION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1tndyb2">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -3208,7 +4054,7 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1n62f5a">
-          <text></text>
+          <text>-</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0plwt4o">
           <text>true</text>
@@ -3232,9 +4078,150 @@ else false</text>
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_0kszdf2">
+        <inputEntry id="UnaryTests_0w798jl">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vit2bq">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01p7pgd">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1wh11fb">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06e6kl4">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0dn4zw7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1eencfq">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1my400k">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0sv3q08">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11c5q5e">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0dw2lpk">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_00v55ls">
+          <text>"ReviewApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0gvh3nf">
+          <text>"Application for multiple types"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0k5d6i7">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0977v4t">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0g5vsnt">
+        <inputEntry id="UnaryTests_175oo46">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qed6ep">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1arlvng">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16nnpq7">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0e9sgrz">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04ksfwu">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0msaues">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fdd274">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1llq41o">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1c60en2">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1tc4nr1">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0j2hgsw">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0l9tjqk">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1mctzzx">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_18d0zvk">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0vzvnc4">
+        <inputEntry id="UnaryTests_04n1656">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_099q67l">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0n5o3vj">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17lcgj6">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1b9utcz">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0l4kfzs">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15d4p3o">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mar4u1">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qfoe3o">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0cb3dfg">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1difq19">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1lthigc">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0mpcwvf">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1g1ci7s">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1cs6v4t">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_1rc4tj5">
         <inputEntry id="UnaryTests_1pxo4pk">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION","CHANGE_STATE_TO_AWAITING_JUDICIAL_DECISION"</text>
+          <text>"TRIGGER_LOCATION_UPDATE","CHANGE_STATE_TO_AWAITING_JUDICIAL_DECISION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0zeoke1">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -3255,7 +4242,7 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0rv2024">
-          <text></text>
+          <text>-</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1bv1bmj">
           <text>true</text>
@@ -3276,6 +4263,147 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0xzg3g0">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1ezbodu">
+        <inputEntry id="UnaryTests_144fn8k">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fzbpda">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1wclwr7">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_012qyym">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01leayg">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0woyzuv">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04iyzy1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1l5zqdw">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17nj0bl">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0oh6mfp">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17dgu14">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0ajgcan">
+          <text>"ReviewApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0tkigk0">
+          <text>"Application for multiple types"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1cynxpy">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1st2jsv">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1m1h38d">
+        <inputEntry id="UnaryTests_0il43fm">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0rn0d7o">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0uh16mc">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12m5ql5">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tfhl79">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0r2dwie">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xvnkvk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04rznn8">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0mbpu1x">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12s4b8e">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1azh2oc">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0eslkqu">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1n4j8jn">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_10fti44">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0oxtzfu">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1z03ev4">
+        <inputEntry id="UnaryTests_1bg9f78">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1c9iuk2">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xm5qdo">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18c0zw1">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jav3pe">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19psq12">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1a9gcwq">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1hrtmqf">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jq1s9s">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ae7zuj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ggjor0">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0hlikf4">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0gunqz6">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ns1bz9">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1r6y7os">
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
@@ -3652,382 +4780,6 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1izz15s">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_06m0jtq">
-        <inputEntry id="UnaryTests_0856b4w">
-          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1ki751v">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1hnlouk">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1u7nkg4">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1b18n76">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0xvre6w">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_15rtbbo">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1e4577z">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0hl4vh6">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0s36l3a">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0fmuryh">
-          <text>-</text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_0ry24yp">
-          <text>"JudgeRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_12zekzn">
-          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1mp2wsu">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0kjovqf">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0l0ymgz">
-        <inputEntry id="UnaryTests_1xmonk4">
-          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_05oncvw">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1plfxej">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0g2ft8v">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1w27hiu">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1p5istm">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0q5af49">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1wi97oy">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0dh6rq2">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0k7qcbu">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_068957x">
-          <text>-</text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1564q00">
-          <text>"JudgeRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_13528zi">
-          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0tevxw5">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0chxqk1">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_12xhfxl">
-        <inputEntry id="UnaryTests_0u4bkgo">
-          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1nhfeu0">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_06qwhfs">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0kjw09p">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0mjuvay">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_18i5dzj">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1fdv4a5">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0hg43iy">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_19o7vb8">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1sw0h6f">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1hjliss">
-          <text>true</text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_14b6k66">
-          <text>"LegalAdvisorRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0l2rdnd">
-          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_073qb8r">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_00vpoow">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0n7uoap">
-        <inputEntry id="UnaryTests_1pkejns">
-          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0to7769">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_044pjqz">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_01vg88m">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_005zhu6">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1tg60al">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1jn7dgj">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_029xhge">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1qerixt">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1bgzh1a">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0pioj2u">
-          <text>true</text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1vw4rqs">
-          <text>"LegalAdvisorRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0e1q997">
-          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0ck4d4a">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0a6yfma">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0i45oye">
-        <inputEntry id="UnaryTests_0mpnwsj">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_15evo5l">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0wpfy7o">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0fsvi21">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1awrp0r">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1weihjq">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_14v81lx">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1it5jay">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1dypqou">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1ivr5ww">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0zlmomx">
-          <text>-</text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1pgb82e">
-          <text>"JudgeRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1jzl1s6">
-          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1ttn8qj">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_00jx47g">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_07rs714">
-        <inputEntry id="UnaryTests_0gg5h31">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0bhm5ox">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1jol7jk">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1msi92b">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0dib5pz">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0yw8wjr">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0x3mqbn">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_16pacex">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_053oaz6">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_18mhghy">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1bwhf9g">
-          <text>-</text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_0qjorai">
-          <text>"JudgeRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0mvzir7">
-          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0hodo3m">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1ocn74p">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0ntp3pt">
-        <inputEntry id="UnaryTests_0a6w83s">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1tlyehw">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1jgedi2">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0nqoldr">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_05r7k6o">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0syh5xw">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0to1wb2">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0vi8icv">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1ftju2j">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1kvphah">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0kxjquy">
-          <text>true</text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1g1bs85">
-          <text>"LegalAdvisorRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_167rwi1">
-          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_05r3b7w">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1ebumjq">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_04rjqlb">
-        <inputEntry id="UnaryTests_01xg98h">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_077tv0h">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_09gvsqh">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1nk4fjh">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0whrryo">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_08okkku">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1jl2wff">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1vexxi4">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1q2eivq">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_14g94of">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0x40dzo">
-          <text>true</text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1kej30k">
-          <text>"LegalAdvisorRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0zyj2ub">
-          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0i5s42k">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1eunqf1">
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>

--- a/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
@@ -62,6 +62,18 @@ or list contains(additionalData.Data.generalAppType.types, "OTHER"))) then false
 else if (additionalData.Data.generalAppConsentOrder != null ) then true else false</text>
         </inputExpression>
       </input>
+      <input id="InputClause_1s4wp88" label="isAlreadyReferedToJudge">
+        <inputExpression id="LiteralExpression_0xukk5x" typeRef="string">
+          <text>if(additionalData.Data.referToJudge!= null) then true
+else false</text>
+        </inputExpression>
+      </input>
+      <input id="InputClause_0fu4z6v" label="isAlreadyReferedToLegalAdvisor">
+        <inputExpression id="LiteralExpression_0f4ckhm" typeRef="boolean">
+          <text>if(additionalData.Data.referToLegalAdvisor!= null) then true
+else false</text>
+        </inputExpression>
+      </input>
       <output id="Output_1" label="Task Id" name="taskId" typeRef="string" biodi:width="150" />
       <output id="OutputClause_07cuas3" label="Name" name="name" typeRef="string" biodi:width="215" />
       <output id="OutputClause_00r3jrp" label="Delay Until" name="delayUntil" typeRef="json" />
@@ -90,6 +102,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_0oecj2r">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1wtwdv7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qel832">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_19k6yf0">
           <text>"JudgeDecideOnApplication"</text>
@@ -129,6 +147,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_0ynqp6p">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0u4bte5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0cgk759">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_1rq2qff">
           <text>"JudgeDecideOnApplication"</text>
         </outputEntry>
@@ -166,6 +190,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_0gnvjbg">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0spvc5y">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1axeetp">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1clx2to">
           <text>"JudgeDecideOnApplication"</text>
@@ -205,6 +235,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_0860y5x">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1a4sy6m">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0u0okec">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_0fjn773">
           <text>"JudgeDecideOnApplication"</text>
         </outputEntry>
@@ -242,6 +278,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_0b1mcb9">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ww4l56">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0f1xh1a">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1byj9oo">
           <text>"JudgeDecideOnApplication"</text>
@@ -281,6 +323,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1axg4dz">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1nrxaz8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wsgzlr">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_0hgnh84">
           <text>"JudgeDecideOnApplication"</text>
         </outputEntry>
@@ -318,6 +366,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_0xa66oj">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_113nqz0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0caxo3h">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0g39o9x">
           <text>"JudgeDecideOnApplication"</text>
@@ -357,6 +411,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1nv3zb5">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0vev614">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12gda8c">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_10ylebb">
           <text>"JudgeDecideOnApplication"</text>
         </outputEntry>
@@ -394,6 +454,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_0rfbpao">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0uwh4yo">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1af78ur">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_06fmowc">
           <text>"JudgeRevisitApplication"</text>
@@ -433,6 +499,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1kw60fr">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1vlivok">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0572fpi">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_0klcmvw">
           <text>"JudgeRevisitApplication"</text>
         </outputEntry>
@@ -470,6 +542,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_02qntb0">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1642wcy">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ynlq2c">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_13j65ad">
           <text>"JudgeRevisitApplication"</text>
@@ -509,6 +587,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_19b1bck">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_084whfm">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04nglp9">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_1k2c1lu">
           <text>"JudgeRevisitApplication"</text>
         </outputEntry>
@@ -546,6 +630,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_1n83kdv">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1v096uc">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_008vwus">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_11k0m26">
           <text>"JudgeDecideOnApplication"</text>
@@ -585,6 +675,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1ob30il">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_00i9b3q">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pvddev">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_1qbeiv9">
           <text>"JudgeDecideOnApplication"</text>
         </outputEntry>
@@ -622,6 +718,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_1jxo8qd">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12lp4i1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ruvp99">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0r77rli">
           <text>"JudgeDecideOnApplication"</text>
@@ -661,6 +763,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_0bhn0wf">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1f2zpq2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_109fe08">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_0zy5qun">
           <text>"JudgeDecideOnApplication"</text>
         </outputEntry>
@@ -698,6 +806,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_1mnixvx">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_193dfzw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jcw6mq">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1cc672h">
           <text>"JudgeDecideOnApplication"</text>
@@ -737,6 +851,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1nocxyu">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1vi13vr">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05rgewj">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_1mv0jm6">
           <text>"JudgeDecideOnApplication"</text>
         </outputEntry>
@@ -774,6 +894,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_098s97s">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0txt1on">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qdu889">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0ap44ze">
           <text>"JudgeDecideOnApplication"</text>
@@ -813,6 +939,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_0nlhqqq">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1n3l5rq">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1hmhpg6">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_064ppc7">
           <text>"JudgeDecideOnApplication"</text>
         </outputEntry>
@@ -850,6 +982,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_0b9l26t">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bmclva">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fs5nbi">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1koynfj">
           <text>"JudgeRevisitApplication"</text>
@@ -889,6 +1027,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_0eu4g7d">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0oc7z1h">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06iqpwr">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_1fg0agz">
           <text>"JudgeRevisitApplication"</text>
         </outputEntry>
@@ -926,6 +1070,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_00ni92y">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09dn1rp">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vlg1js">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0gp4qc3">
           <text>"JudgeRevisitApplication"</text>
@@ -965,6 +1115,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1i3vkpo">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1a76uxh">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mzrrcr">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_11xxo5d">
           <text>"JudgeRevisitApplication"</text>
         </outputEntry>
@@ -1002,6 +1158,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_1pzycwi">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ux63ok">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05awy2i">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0ldczpl">
           <text>"LegalAdvisorDecideOnApplication"</text>
@@ -1041,6 +1203,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_11i3x3n">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0ta4n2b">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0e5jq2s">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_1i1ddux">
           <text>"LegalAdvisorDecideOnApplication"</text>
         </outputEntry>
@@ -1078,6 +1246,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_1yvjg00">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16v9cm2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1y8a4n0">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1ms199v">
           <text>"LegalAdvisorDecideOnApplication"</text>
@@ -1117,6 +1291,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_0ju2tv3">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_18v3sz8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1d6wga1">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_13idhzk">
           <text>"LegalAdvisorDecideOnApplication"</text>
         </outputEntry>
@@ -1154,6 +1334,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_0syvzhl">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ti3033">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0m7mdkd">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0m0vm39">
           <text>"LegalAdvisorDecideOnApplication"</text>
@@ -1193,6 +1379,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_0r0pl1q">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_04vu6po">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ley89c">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_1r8iytb">
           <text>"LegalAdvisorDecideOnApplication"</text>
         </outputEntry>
@@ -1230,6 +1422,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_0jxjecy">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0w0hgdm">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1af6z3j">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_09q89pi">
           <text>"LegalAdvisorDecideOnApplication"</text>
@@ -1269,6 +1467,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1d7iegw">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_10hrp0l">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1gu9aat">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_1wmcw3v">
           <text>"LegalAdvisorDecideOnApplication"</text>
         </outputEntry>
@@ -1306,6 +1510,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_0nwnvhj">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_165uwx9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1b3bv3z">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1ky5b35">
           <text>"LegalAdvisorRevisitApplication"</text>
@@ -1345,6 +1555,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_09drgg4">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0f7b5a4">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0mei6i3">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_0oy665s">
           <text>"LegalAdvisorRevisitApplication"</text>
         </outputEntry>
@@ -1382,6 +1598,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_090vkn1">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1wj5umc">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ko2kuq">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1xoskn0">
           <text>"LegalAdvisorRevisitApplication"</text>
@@ -1421,6 +1643,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1q938s7">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_18wiqty">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04aye77">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_1aaoz3m">
           <text>"LegalAdvisorRevisitApplication"</text>
         </outputEntry>
@@ -1458,6 +1686,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_10nhxqs">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0o57zfw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0dybta8">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1kioqvw">
           <text>"ReviewApplication"</text>
@@ -1497,6 +1731,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1ur1rh5">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_06dzeuj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14ax91l">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_0p2v2k2">
           <text>"ReviewApplication"</text>
         </outputEntry>
@@ -1534,6 +1774,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_0oro08q">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0bx2c5r">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qn8sa0">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1bikefj">
           <text>"ReviewApplication"</text>
@@ -1573,6 +1819,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_0gkzm4q">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0ope7wa">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hzafo8">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_0y57ij9">
           <text>"ReviewApplication"</text>
         </outputEntry>
@@ -1610,6 +1862,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_021xvdp">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11944md">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1v1nuzj">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0mb866c">
           <text>"ReviewApplication"</text>
@@ -1649,6 +1907,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1dpfvej">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0919haa">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yfcap2">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_1dq85yt">
           <text>"ReviewApplication"</text>
         </outputEntry>
@@ -1686,6 +1950,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_0plwt4o">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qfh7tr">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0eatrtr">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_12pa3g8">
           <text>"ReviewApplication"</text>
@@ -1725,6 +1995,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1bv1bmj">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1crlhit">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16og0wb">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_0zk5cmd">
           <text>"ReviewApplication"</text>
         </outputEntry>
@@ -1762,6 +2038,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_1s9ys7j">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_147ktb0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jzssec">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0x2y7kj">
           <text>"ReviewRevisitedApplication"</text>
@@ -1801,6 +2083,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_0pbf8iy">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1qtkpf1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0975a8a">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_1pe1zwc">
           <text>"ReviewRevisitedApplication"</text>
         </outputEntry>
@@ -1838,6 +2126,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_0ok14tu">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04ikap8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0eyj2x0">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1ltsgio">
           <text>"ReviewRevisitedApplication"</text>
@@ -1877,6 +2171,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1f5lrsk">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1jh5tkn">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0f3uymd">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_0hj40u8">
           <text>"ReviewRevisitedApplication"</text>
         </outputEntry>
@@ -1914,6 +2214,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_15rg2rj">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1rm4olm">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1rsh0h5">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0r80us6">
           <text>"ReviewRevisitedApplication"</text>
@@ -1953,6 +2259,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_0qu3ew4">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_18nofkx">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0eq3brw">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_18a87d5">
           <text>"ReviewRevisitedApplication"</text>
         </outputEntry>
@@ -1990,6 +2302,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         </inputEntry>
         <inputEntry id="UnaryTests_0lkby76">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05u0u0k">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1s832si">
+          <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0b0wu9w">
           <text>"ReviewRevisitedApplication"</text>
@@ -2029,6 +2347,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1tw5cms">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_02j2kxe">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_158ra9p">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_0qjtnd9">
           <text>"ReviewRevisitedApplication"</text>
         </outputEntry>
@@ -2039,6 +2363,182 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1izz15s">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_06m0jtq">
+        <inputEntry id="UnaryTests_0856b4w">
+          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ki751v">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1hnlouk">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1u7nkg4">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1b18n76">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xvre6w">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15rtbbo">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hl4vh6">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0s36l3a">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fmuryh">
+          <text>false</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0ry24yp">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_12zekzn">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1mp2wsu">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0kjovqf">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0l0ymgz">
+        <inputEntry id="UnaryTests_1xmonk4">
+          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05oncvw">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1plfxej">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0g2ft8v">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1w27hiu">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1p5istm">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0q5af49">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0dh6rq2">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0k7qcbu">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_068957x">
+          <text>false</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1564q00">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_13528zi">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0tevxw5">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0chxqk1">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_12xhfxl">
+        <inputEntry id="UnaryTests_0u4bkgo">
+          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1nhfeu0">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06qwhfs">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kjw09p">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0mjuvay">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18i5dzj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fdv4a5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19o7vb8">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1sw0h6f">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1hjliss">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_14b6k66">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0l2rdnd">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_073qb8r">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_00vpoow">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0n7uoap">
+        <inputEntry id="UnaryTests_1pkejns">
+          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0to7769">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_044pjqz">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01vg88m">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_005zhu6">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1tg60al">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jn7dgj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qerixt">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bgzh1a">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pioj2u">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1vw4rqs">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0e1q997">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ck4d4a">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0a6yfma">
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
@@ -2065,6 +2565,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1mw376f">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zpym82">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jk8qh2">
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1ebwxnh">
@@ -2105,6 +2611,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_00mjp2t">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_14aqlwq">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qacxgm">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_1gybrb2">
           <text>"ScheduleApplicationHearing"</text>
         </outputEntry>
@@ -2141,6 +2653,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_13tb2iv">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12gi93k">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0v9kufl">
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0xi5g57">
@@ -2181,6 +2699,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_0j24wpm">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1h5t43b">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qhmo1v">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_1axlw74">
           <text>"ScheduleApplicationHearing"</text>
         </outputEntry>
@@ -2217,6 +2741,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1qqsirc">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0z3zisk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0mgommh">
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1l4b7kk">
@@ -2257,6 +2787,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1japzxm">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1wpsfdc">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pnbcm5">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_18du2tv">
           <text>"ReviewStayTheClaimApplicationOrder"</text>
         </outputEntry>
@@ -2293,6 +2829,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0hzsq1i">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03azrte">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06qz4yg">
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0pcz0gq">
@@ -2333,6 +2875,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1dzx7ph">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1wtezix">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18q0blm">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_0a6w1c9">
           <text>"ReviewStayTheClaimApplicationOrder"</text>
         </outputEntry>
@@ -2369,6 +2917,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ii8lzs">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10223wl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kd0knm">
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_02nzepj">
@@ -2409,6 +2963,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_086yycn">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1vuhmt9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1up0xdo">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_08gwytv">
           <text>"ReviewUnlessOrderApplication"</text>
         </outputEntry>
@@ -2445,6 +3005,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0zwlkzn">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1akl7uc">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0i3s6kf">
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1czofx7">
@@ -2485,6 +3051,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1c0evmr">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_05pg0nl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1sfk6hf">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_0vxpqbm">
           <text>"ReviewUnlessOrderApplication"</text>
         </outputEntry>
@@ -2521,6 +3093,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0gdzf2a">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1iklz03">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tfh4nf">
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1wzhh25">
@@ -2561,6 +3139,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1p5fl06">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1dthdza">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0z7zl4r">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_0tmesym">
           <text>"JudgeDecideOnApplication"</text>
         </outputEntry>
@@ -2599,6 +3183,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1l7veu4">
           <text>-</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0avxtni">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1h9e7u4">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_09qcjno">
           <text>"JudgeDecideOnApplication"</text>
         </outputEntry>
@@ -2635,6 +3225,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0jv449h">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0rpwzgr">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1at7ava">
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_12puein">
@@ -2675,6 +3271,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_02m6vo1">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1jq8fta">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1en8aoa">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_13u732w">
           <text>"JudgeDecideOnApplication"</text>
         </outputEntry>
@@ -2711,6 +3313,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_063svbt">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fsbtio">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0l8qp6o">
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1az2k75">
@@ -2751,6 +3359,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_0m1meou">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_02f9v27">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wr2ndf">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_0rhqunc">
           <text>"JudgeDecideOnApplication"</text>
         </outputEntry>
@@ -2787,6 +3401,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ai2d2d">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vyzqz0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0jis9nt">
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1nynzrd">
@@ -2827,6 +3447,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1cvbrze">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1m7339v">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pjsbi4">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_1kwmler">
           <text>"JudgeDecideOnApplication"</text>
         </outputEntry>
@@ -2863,6 +3489,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ahyxn9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17mujco">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18txghx">
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1re6kjk">
@@ -2903,6 +3535,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_0igf5h7">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1ar78ai">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0j48o7w">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_0jk8ych">
           <text>"JudgeRevisitApplication"</text>
         </outputEntry>
@@ -2939,6 +3577,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0jtpsxa">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0t1vxqe">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_048ytou">
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0ur34qp">
@@ -2979,6 +3623,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_0b4m0ua">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_08ko5eb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1duruel">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_0xrhqim">
           <text>"JudgeRevisitApplication"</text>
         </outputEntry>
@@ -3015,6 +3665,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1h0yz3c">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16b4vfh">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0x4o91o">
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1ww59bd">
@@ -3055,6 +3711,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_0dpqy55">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0x71sse">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09lwc0e">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_1ydeujr">
           <text>"LegalAdvisorDecideOnApplication"</text>
         </outputEntry>
@@ -3091,6 +3753,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0vxvk6s">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ynots6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10udkay">
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_05luutp">
@@ -3131,6 +3799,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1h1jqt7">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_06ukd0b">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0g43k52">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_1lo90sq">
           <text>"LegalAdvisorDecideOnApplication"</text>
         </outputEntry>
@@ -3167,6 +3841,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0dwtrqe">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ay909n">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1tcv22d">
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0ocgpn4">
@@ -3209,6 +3889,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_1gijj60">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0cqds7h">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0dmrfju">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_109ics6">
           <text>"LegalAdvisorRevisitApplication"</text>
         </outputEntry>
@@ -3249,6 +3935,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
         <inputEntry id="UnaryTests_0e4unxx">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1bmbh5w">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tb41t4">
+          <text></text>
+        </inputEntry>
         <outputEntry id="LiteralExpression_0ge467a">
           <text>"LegalAdvisorRevisitApplication"</text>
         </outputEntry>
@@ -3285,6 +3977,12 @@ else if (additionalData.Data.generalAppConsentOrder != null ) then true else fal
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_067j89w">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1398lbx">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_08jal0t">
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0kjclot">

--- a/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
@@ -47,7 +47,7 @@ or (list contains(additionalData.Data.generalAppType.types, "AMEND_A_STMT_OF_CAS
 or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT") and additionalData.Data.generalAppSuperClaimType = "SPEC_CLAIM")</text>
         </inputExpression>
       </input>
-      <input id="InputClause_02roxxa" label="isConsentOrderApplication" biodi:width="192" camunda:inputVariable="isConsentOrder">
+      <input id="InputClause_02roxxa" label="isConsentOrderTypeReferToCaseWorker" biodi:width="205" camunda:inputVariable="isConsentOrder">
         <inputExpression id="LiteralExpression_0tohamv" typeRef="boolean">
           <text>if(additionalData.Data.generalAppConsentOrder != null
 and(list contains(additionalData.Data.generalAppType.types, "STRIKE_OUT")

--- a/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
@@ -47,6 +47,11 @@ or (list contains(additionalData.Data.generalAppType.types, "AMEND_A_STMT_OF_CAS
 or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT") and additionalData.Data.generalAppSuperClaimType = "SPEC_CLAIM")</text>
         </inputExpression>
       </input>
+      <input id="InputClause_1fby0c6" label="isDecisionMadeOnConsentOrder">
+        <inputExpression id="LiteralExpression_00u1rae" typeRef="boolean">
+          <text>if(additionalData.Data.generalAppConsentOrder != null and additionalData.Data.judicialDecision != null) then true else false</text>
+        </inputExpression>
+      </input>
       <input id="InputClause_02roxxa" label="isConsentOrderTypeReferToCaseWorker" biodi:width="205" camunda:inputVariable="isConsentOrder">
         <inputExpression id="LiteralExpression_0tohamv" typeRef="boolean">
           <text>if(additionalData.Data.generalAppConsentOrder != null
@@ -100,6 +105,9 @@ else false</text>
         <inputEntry id="UnaryTests_021pra5">
           <text>-</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1cwv4zk">
+          <text>false</text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0oecj2r">
           <text>false</text>
         </inputEntry>
@@ -119,6 +127,53 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_01w0e9q">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1oe52fu">
+        <inputEntry id="UnaryTests_1kblm07">
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09pva3e">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0znb0q3">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vhodi7">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_019dcja">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_07se19m">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19y8lxz">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vjhbg6">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0w1opq4">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vwpk6y">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0074ifn">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0lv3arr">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_13vrw8r">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0226j25">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0uke1qa">
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
@@ -144,6 +199,9 @@ else false</text>
         <inputEntry id="UnaryTests_1d8ji83">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_14iprg1">
+          <text>false</text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0ynqp6p">
           <text>false</text>
         </inputEntry>
@@ -163,6 +221,53 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_19li7yq">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1ojr1q7">
+        <inputEntry id="UnaryTests_0v60a7d">
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_067q65n">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0q7szey">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14i41iv">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0uos42i">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1r7x92z">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_174w6sf">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_010h9s6">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tcmxll">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12tl6w2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1y508yf">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0jbf89t">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0w9cmiv">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0v4s08u">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1gmuek2">
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
@@ -188,6 +293,9 @@ else false</text>
         <inputEntry id="UnaryTests_1b72x9q">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0y0hcg2">
+          <text>false</text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0gnvjbg">
           <text>false</text>
         </inputEntry>
@@ -207,6 +315,53 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0g1pv16">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1629all">
+        <inputEntry id="UnaryTests_00a39tq">
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1e8v3yn">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1x2p4hf">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0h3gwj9">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1x605mo">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0a2h6j6">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1y3kqtl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1i0k8qe">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0klry2i">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0e6wwkw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0cghr1q">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0iw4uye">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1yf7ywb">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1606hp3">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ze02l2">
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
@@ -232,6 +387,9 @@ else false</text>
         <inputEntry id="UnaryTests_1hcm5a9">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0j3hchf">
+          <text>false</text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0860y5x">
           <text>false</text>
         </inputEntry>
@@ -251,6 +409,53 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_17zwv52">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0ljsxk4">
+        <inputEntry id="UnaryTests_1u494uw">
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1hl8neb">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1k41kzk">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1b7miit">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1j57an4">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qusdcb">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1tj8745">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14okiss">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bo5jfs">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1adxtgs">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ny5ul8">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1t5qz96">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0r36m8p">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_06w27lb">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0pqipaf">
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
@@ -274,6 +479,9 @@ else false</text>
           <text>true</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0ex0j2w">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0t13m9u">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0b1mcb9">
@@ -320,6 +528,9 @@ else false</text>
         <inputEntry id="UnaryTests_17ykwiq">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1f55y1m">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1axg4dz">
           <text>false</text>
         </inputEntry>
@@ -362,6 +573,9 @@ else false</text>
           <text>true</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1g6mnux">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_00yraxg">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0xa66oj">
@@ -408,6 +622,9 @@ else false</text>
         <inputEntry id="UnaryTests_14i2pu5">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_10ol483">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1nv3zb5">
           <text>false</text>
         </inputEntry>
@@ -450,6 +667,9 @@ else false</text>
           <text>true</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1uh11uy">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0674ap0">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0rfbpao">
@@ -496,6 +716,9 @@ else false</text>
         <inputEntry id="UnaryTests_14k1ysf">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_19hs2rj">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1kw60fr">
           <text>false</text>
         </inputEntry>
@@ -538,6 +761,9 @@ else false</text>
           <text>true</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1imgu52">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11usdiz">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_02qntb0">
@@ -584,6 +810,9 @@ else false</text>
         <inputEntry id="UnaryTests_1x2plyt">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_03330g3">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_19b1bck">
           <text>false</text>
         </inputEntry>
@@ -626,6 +855,9 @@ else false</text>
           <text>true</text>
         </inputEntry>
         <inputEntry id="UnaryTests_11ozh57">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tc46bs">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ca09d2">
@@ -672,6 +904,9 @@ else false</text>
         <inputEntry id="UnaryTests_0guizd1">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1fwwa7i">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_02b2hh8">
           <text>false</text>
         </inputEntry>
@@ -714,6 +949,9 @@ else false</text>
           <text>true</text>
         </inputEntry>
         <inputEntry id="UnaryTests_15nmkxu">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ndqcso">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1wozqed">
@@ -760,6 +998,9 @@ else false</text>
         <inputEntry id="UnaryTests_08ces6d">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1uqa4zw">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_11mdgyi">
           <text>false</text>
         </inputEntry>
@@ -804,6 +1045,9 @@ else false</text>
         <inputEntry id="UnaryTests_0evoa6n">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1atcya3">
+          <text>false</text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1n83kdv">
           <text>false</text>
         </inputEntry>
@@ -823,6 +1067,53 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1aq4zvp">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_03n59jn">
+        <inputEntry id="UnaryTests_1bn3ox4">
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pz3beg">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1rvasme">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0er0cja">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lnfk67">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1tmov20">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0my9x5a">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0e42qw5">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pu1nrc">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1wfvaw6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1n2ib5i">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1832dur">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_004yt5x">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0u28q4h">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0gbhpme">
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
@@ -848,6 +1139,9 @@ else false</text>
         <inputEntry id="UnaryTests_0n500e8">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1srtx6l">
+          <text>false</text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1ob30il">
           <text>false</text>
         </inputEntry>
@@ -867,6 +1161,53 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0mpq4m1">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_08dq3zo">
+        <inputEntry id="UnaryTests_13nyips">
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1h8i09b">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19ml0qi">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xmdkbp">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ei0zoj">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1v91tyb">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0d1thig">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0bgsvhj">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0r6o9fq">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ctv0pu">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1t9ncru">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0xy959q">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_18plk4o">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_08usqg1">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1lmbmub">
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
@@ -892,6 +1233,9 @@ else false</text>
         <inputEntry id="UnaryTests_18gw3g5">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_08z91nl">
+          <text>false</text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1jxo8qd">
           <text>false</text>
         </inputEntry>
@@ -911,6 +1255,53 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1dzzl2b">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1rhvwkh">
+        <inputEntry id="UnaryTests_18p7gsd">
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13n2gsp">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0k9ui7j">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ce2myr">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hqh1ko">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0w4j3p9">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qm13pt">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1cb22bh">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ulb5he">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tin0ob">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01wx8zg">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_108nxx6">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1e6z32z">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ni8sg7">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1tgrww6">
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
@@ -936,6 +1327,9 @@ else false</text>
         <inputEntry id="UnaryTests_0gibemn">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_04d5utf">
+          <text>false</text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0bhn0wf">
           <text>false</text>
         </inputEntry>
@@ -955,6 +1349,53 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1yuoynr">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0t4vv8c">
+        <inputEntry id="UnaryTests_05nrs3f">
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ibtwjr">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17y1ugb">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0u1eqj8">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1z0e4px">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18gs10z">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ciz88v">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kuwbh9">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0238cs4">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ythctu">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0r01esw">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0sla9x7">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1vg45h2">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1xckeol">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0sec183">
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
@@ -979,6 +1420,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_17g21r0">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1g8yatz">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1mnixvx">
           <text>false</text>
@@ -1024,6 +1468,9 @@ else false</text>
         <inputEntry id="UnaryTests_0x9jgfr">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_01u90tf">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1nocxyu">
           <text>false</text>
         </inputEntry>
@@ -1067,6 +1514,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_028c4o8">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1hbi7oq">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_098s97s">
           <text>false</text>
@@ -1112,6 +1562,9 @@ else false</text>
         <inputEntry id="UnaryTests_1mh6pnz">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_02khbwg">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0nlhqqq">
           <text>false</text>
         </inputEntry>
@@ -1155,6 +1608,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0te1iqe">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1hjqkyv">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0b9l26t">
           <text>false</text>
@@ -1200,6 +1656,9 @@ else false</text>
         <inputEntry id="UnaryTests_16eh5q3">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0pjwmk5">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0eu4g7d">
           <text>false</text>
         </inputEntry>
@@ -1243,6 +1702,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0pvpz9y">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jc9zxw">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_00ni92y">
           <text>false</text>
@@ -1288,6 +1750,9 @@ else false</text>
         <inputEntry id="UnaryTests_176lhxs">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0svvusn">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1i3vkpo">
           <text>false</text>
         </inputEntry>
@@ -1331,6 +1796,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1gktnlj">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qwtj95">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0ool9cq">
           <text>false</text>
@@ -1376,6 +1844,9 @@ else false</text>
         <inputEntry id="UnaryTests_0stmbbn">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0ykwulg">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0on9sli">
           <text>false</text>
         </inputEntry>
@@ -1419,6 +1890,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1nrv7qr">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1sd28bu">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_07ryt8f">
           <text>false</text>
@@ -1464,6 +1938,9 @@ else false</text>
         <inputEntry id="UnaryTests_14k1ngq">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_06mbwl0">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_06lvzet">
           <text>false</text>
         </inputEntry>
@@ -1508,6 +1985,9 @@ else false</text>
         <inputEntry id="UnaryTests_0zt27la">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_124ckqo">
+          <text>false</text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1pzycwi">
           <text>false</text>
         </inputEntry>
@@ -1527,6 +2007,53 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0rfhopv">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1mfbwke">
+        <inputEntry id="UnaryTests_0qg31ug">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mnwpwh">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ncadsz">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0u9poue">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1glb2fx">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1azyg08">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19yyg85">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0piks8a">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yz2d42">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0o5b9q9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1rru1qf">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0cnvgpl">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1pjqzfu">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_14q6s85">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_13u5g2s">
           <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
@@ -1552,6 +2079,9 @@ else false</text>
         <inputEntry id="UnaryTests_0u2zgm4">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1la5xsj">
+          <text>false</text>
+        </inputEntry>
         <inputEntry id="UnaryTests_11i3x3n">
           <text>false</text>
         </inputEntry>
@@ -1571,6 +2101,53 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_001ncrx">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_04f1h1y">
+        <inputEntry id="UnaryTests_1yy0s09">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0bp7ii2">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1lqhmtq">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lymf5b">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vmkvkh">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1maq2b0">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zd0joh">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18nif2l">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yuyoo0">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15rev7y">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1t0zisd">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1feliu1">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0c3fri3">
+          <text>"lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1mwyk2c">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1cdsyjs">
           <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
@@ -1596,6 +2173,9 @@ else false</text>
         <inputEntry id="UnaryTests_1d4zfj1">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_14derqs">
+          <text>false</text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1yvjg00">
           <text>false</text>
         </inputEntry>
@@ -1615,6 +2195,53 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0562dm9">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1n3zfgr">
+        <inputEntry id="UnaryTests_087oxs0">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uws2p9">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0oydzen">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0n5inft">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hd6lpi">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0p88qv0">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1k3md73">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0c25f8v">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0y5iwbh">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1colcih">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1b08xd5">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_069vfzg">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_03ltfhw">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1m37qyx">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0h63i0x">
           <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
@@ -1640,6 +2267,9 @@ else false</text>
         <inputEntry id="UnaryTests_1a8bcyh">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1j5yh4z">
+          <text>false</text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0ju2tv3">
           <text>false</text>
         </inputEntry>
@@ -1659,6 +2289,53 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0quqdhw">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1qfzt3k">
+        <inputEntry id="UnaryTests_125a75h">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0l7bm3k">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vvvt0f">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14b275c">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lvf647">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_194bw9v">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yg6yce">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1k0pipj">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1xb6291">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1dnfq05">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0bft49e">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0qwh860">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1gqs3d0">
+          <text>"lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0lmcaeg">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1njnz5f">
           <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
@@ -1683,6 +2360,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0boqtmc">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0g0vmro">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0syvzhl">
           <text>false</text>
@@ -1728,6 +2408,9 @@ else false</text>
         <inputEntry id="UnaryTests_0h6065w">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_08iya5z">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0r0pl1q">
           <text>false</text>
         </inputEntry>
@@ -1771,6 +2454,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1tihkpb">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_00mzp2l">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0jxjecy">
           <text>false</text>
@@ -1816,6 +2502,9 @@ else false</text>
         <inputEntry id="UnaryTests_0s2e5ep">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0sx06k3">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1d7iegw">
           <text>false</text>
         </inputEntry>
@@ -1859,6 +2548,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0nfyptk">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0s62b59">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0nwnvhj">
           <text>false</text>
@@ -1904,6 +2596,9 @@ else false</text>
         <inputEntry id="UnaryTests_1k6yck6">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0v7ivel">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_09drgg4">
           <text>false</text>
         </inputEntry>
@@ -1947,6 +2642,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1nx307b">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1n2x9wp">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_090vkn1">
           <text>false</text>
@@ -1992,6 +2690,9 @@ else false</text>
         <inputEntry id="UnaryTests_17w0vpg">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_18jsbgo">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1q938s7">
           <text>false</text>
         </inputEntry>
@@ -2035,6 +2736,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_16b02d1">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1lh4q1i">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1k32t4w">
           <text>false</text>
@@ -2080,6 +2784,9 @@ else false</text>
         <inputEntry id="UnaryTests_1an8fxt">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1thdnd5">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1gh2plu">
           <text>false</text>
         </inputEntry>
@@ -2123,6 +2830,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1dqhnmi">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qoen3p">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1k9e9x2">
           <text>false</text>
@@ -2168,6 +2878,9 @@ else false</text>
         <inputEntry id="UnaryTests_1gnvl3t">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1i0a1lv">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0sm1dn8">
           <text>false</text>
         </inputEntry>
@@ -2210,6 +2923,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1vrw394">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1lasnoi">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_10nhxqs">
@@ -2256,6 +2972,9 @@ else false</text>
         <inputEntry id="UnaryTests_1xoucq5">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0sgsfa4">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1ur1rh5">
           <text>true</text>
         </inputEntry>
@@ -2298,6 +3017,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0i6xlww">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10vmgyz">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0oro08q">
@@ -2344,6 +3066,9 @@ else false</text>
         <inputEntry id="UnaryTests_1trw8zr">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0lc3z7k">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0gkzm4q">
           <text>true</text>
         </inputEntry>
@@ -2386,6 +3111,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0vn84pl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lggg09">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_021xvdp">
@@ -2432,6 +3160,9 @@ else false</text>
         <inputEntry id="UnaryTests_1w1xc4k">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1ozbjmo">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1dpfvej">
           <text>true</text>
         </inputEntry>
@@ -2474,6 +3205,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_14u0tlu">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1n62f5a">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0plwt4o">
@@ -2520,6 +3254,9 @@ else false</text>
         <inputEntry id="UnaryTests_1p0rgpq">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0rv2024">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1bv1bmj">
           <text>true</text>
         </inputEntry>
@@ -2562,6 +3299,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0k37fwi">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ssmdnr">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1s9ys7j">
@@ -2608,6 +3348,9 @@ else false</text>
         <inputEntry id="UnaryTests_17mlvih">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1f18qdg">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0pbf8iy">
           <text>true</text>
         </inputEntry>
@@ -2650,6 +3393,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_12mtdse">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0s2bni4">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0ok14tu">
@@ -2696,6 +3442,9 @@ else false</text>
         <inputEntry id="UnaryTests_1p1jl1h">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_029629u">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1f5lrsk">
           <text>true</text>
         </inputEntry>
@@ -2738,6 +3487,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_094hz1q">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1go4lr1">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_15rg2rj">
@@ -2784,6 +3536,9 @@ else false</text>
         <inputEntry id="UnaryTests_0o8z6ua">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_11ts8zs">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0qu3ew4">
           <text>true</text>
         </inputEntry>
@@ -2826,6 +3581,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_11mozzl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1lwi4og">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0lkby76">
@@ -2872,6 +3630,9 @@ else false</text>
         <inputEntry id="UnaryTests_0o1zx4v">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0lqpw64">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1tw5cms">
           <text>true</text>
         </inputEntry>
@@ -2916,6 +3677,9 @@ else false</text>
         <inputEntry id="UnaryTests_15rtbbo">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1e4577z">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0hl4vh6">
           <text>true</text>
         </inputEntry>
@@ -2923,7 +3687,7 @@ else false</text>
           <text>true</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0fmuryh">
-          <text>false</text>
+          <text>-</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0ry24yp">
           <text>"JudgeRevisitApplication"</text>
@@ -2960,6 +3724,9 @@ else false</text>
         <inputEntry id="UnaryTests_0q5af49">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1wi97oy">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0dh6rq2">
           <text>true</text>
         </inputEntry>
@@ -2967,7 +3734,7 @@ else false</text>
           <text>true</text>
         </inputEntry>
         <inputEntry id="UnaryTests_068957x">
-          <text>false</text>
+          <text>-</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1564q00">
           <text>"JudgeRevisitApplication"</text>
@@ -3004,11 +3771,14 @@ else false</text>
         <inputEntry id="UnaryTests_1fdv4a5">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0hg43iy">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_19o7vb8">
           <text>true</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1sw0h6f">
-          <text>false</text>
+          <text>-</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1hjliss">
           <text>true</text>
@@ -3048,11 +3818,14 @@ else false</text>
         <inputEntry id="UnaryTests_1jn7dgj">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_029xhge">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1qerixt">
           <text>true</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1bgzh1a">
-          <text>false</text>
+          <text>-</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0pioj2u">
           <text>true</text>
@@ -3067,6 +3840,194 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0a6yfma">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0i45oye">
+        <inputEntry id="UnaryTests_0mpnwsj">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15evo5l">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wpfy7o">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fsvi21">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1awrp0r">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1weihjq">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14v81lx">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1it5jay">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1dypqou">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ivr5ww">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zlmomx">
+          <text>-</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1pgb82e">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1jzl1s6">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ttn8qj">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_00jx47g">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_07rs714">
+        <inputEntry id="UnaryTests_0gg5h31">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0bhm5ox">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jol7jk">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1msi92b">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0dib5pz">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0yw8wjr">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0x3mqbn">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16pacex">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_053oaz6">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18mhghy">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bwhf9g">
+          <text>-</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0qjorai">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0mvzir7">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0hodo3m">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ocn74p">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0ntp3pt">
+        <inputEntry id="UnaryTests_0a6w83s">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1tlyehw">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jgedi2">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0nqoldr">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05r7k6o">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0syh5xw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0to1wb2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vi8icv">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ftju2j">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1kvphah">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kxjquy">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1g1bs85">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_167rwi1">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_05r3b7w">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ebumjq">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_04rjqlb">
+        <inputEntry id="UnaryTests_01xg98h">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_077tv0h">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09gvsqh">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1nk4fjh">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0whrryo">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_08okkku">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jl2wff">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vexxi4">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1q2eivq">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14g94of">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0x40dzo">
+          <text>true</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1kej30k">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0zyj2ub">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0i5s42k">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1eunqf1">
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
@@ -3090,6 +4051,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0lw3l81">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16rbk9r">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1mw376f">
@@ -3136,6 +4100,9 @@ else false</text>
         <inputEntry id="UnaryTests_1p3lqzu">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0awm9mp">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_00mjp2t">
           <text></text>
         </inputEntry>
@@ -3178,6 +4145,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1s2qe9o">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1wobnml">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_13tb2iv">
@@ -3224,6 +4194,9 @@ else false</text>
         <inputEntry id="UnaryTests_08rba4r">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0n8t17p">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0j24wpm">
           <text></text>
         </inputEntry>
@@ -3266,6 +4239,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ftapj5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wa1tco">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1qqsirc">
@@ -3312,6 +4288,9 @@ else false</text>
         <inputEntry id="UnaryTests_04cw6j5">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_07rw3zn">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1japzxm">
           <text></text>
         </inputEntry>
@@ -3354,6 +4333,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_13s1ae5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03uze9w">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0hzsq1i">
@@ -3400,6 +4382,9 @@ else false</text>
         <inputEntry id="UnaryTests_01pzw7t">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0uykh27">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1dzx7ph">
           <text></text>
         </inputEntry>
@@ -3442,6 +4427,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1884r66">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19plzec">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ii8lzs">
@@ -3488,6 +4476,9 @@ else false</text>
         <inputEntry id="UnaryTests_095qrvk">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0vprgkc">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_086yycn">
           <text></text>
         </inputEntry>
@@ -3530,6 +4521,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1d034yn">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_184nlgr">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0zwlkzn">
@@ -3576,6 +4570,9 @@ else false</text>
         <inputEntry id="UnaryTests_1hdjqxu">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0vzhemm">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1c0evmr">
           <text></text>
         </inputEntry>
@@ -3618,6 +4615,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1jq3fwq">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06e9sjz">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0gdzf2a">
@@ -3664,6 +4664,9 @@ else false</text>
         <inputEntry id="UnaryTests_1iftqfa">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1k1c1mh">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1p5fl06">
           <text></text>
         </inputEntry>
@@ -3706,6 +4709,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0r52bwp">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fazbwg">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1l7veu4">
@@ -3752,6 +4758,9 @@ else false</text>
         <inputEntry id="UnaryTests_0htkvx8">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0010vy8">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0jv449h">
           <text></text>
         </inputEntry>
@@ -3794,6 +4803,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1dn80yb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ztls9z">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_02m6vo1">
@@ -3840,6 +4852,9 @@ else false</text>
         <inputEntry id="UnaryTests_0ppe1cb">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1foro5b">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_063svbt">
           <text></text>
         </inputEntry>
@@ -3882,6 +4897,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0hnvs3n">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ctzvg3">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0m1meou">
@@ -3928,6 +4946,9 @@ else false</text>
         <inputEntry id="UnaryTests_1fxpbfx">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1hx0lyu">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1ai2d2d">
           <text></text>
         </inputEntry>
@@ -3970,6 +4991,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1v6kxpz">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pjsr5y">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1cvbrze">
@@ -4016,6 +5040,9 @@ else false</text>
         <inputEntry id="UnaryTests_047dh4k">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0ysopso">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1ahyxn9">
           <text></text>
         </inputEntry>
@@ -4058,6 +5085,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_06ddayl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1sq3lrm">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0igf5h7">
@@ -4104,6 +5134,9 @@ else false</text>
         <inputEntry id="UnaryTests_0fg5p6j">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_104uvk4">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0jtpsxa">
           <text></text>
         </inputEntry>
@@ -4146,6 +5179,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0pxjlv8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0t84kvw">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0b4m0ua">
@@ -4192,6 +5228,9 @@ else false</text>
         <inputEntry id="UnaryTests_01px2zr">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_12ikw0o">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1h0yz3c">
           <text></text>
         </inputEntry>
@@ -4234,6 +5273,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0gap9rm">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0t3updg">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0dpqy55">
@@ -4280,6 +5322,9 @@ else false</text>
         <inputEntry id="UnaryTests_06ze5kr">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_080kvdj">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0vxvk6s">
           <text></text>
         </inputEntry>
@@ -4324,6 +5369,9 @@ else false</text>
         <inputEntry id="UnaryTests_0nipob4">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0larh20">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1h1jqt7">
           <text></text>
         </inputEntry>
@@ -4366,6 +5414,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0yuto4e">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0s38rm0">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0dwtrqe">
@@ -4414,6 +5465,9 @@ else false</text>
         <inputEntry id="UnaryTests_1h7ci9c">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1695wo7">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1gijj60">
           <text></text>
         </inputEntry>
@@ -4460,6 +5514,9 @@ else false</text>
         <inputEntry id="UnaryTests_0dtuuji">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1hkz01c">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0e4unxx">
           <text></text>
         </inputEntry>
@@ -4502,6 +5559,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0suqabc">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16oyyub">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_067j89w">

--- a/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
@@ -47,7 +47,7 @@ or (list contains(additionalData.Data.generalAppType.types, "AMEND_A_STMT_OF_CAS
 or (list contains(additionalData.Data.generalAppType.types, "SET_ASIDE_JUDGEMENT") and additionalData.Data.generalAppSuperClaimType = "SPEC_CLAIM")</text>
         </inputExpression>
       </input>
-      <input id="InputClause_1fby0c6" label="isDecisionMadeOnConsentOrder">
+      <input id="InputClause_1fby0c6" label="isDecisionMadeOnConsentOrder" camunda:inputVariable="isDecisionMadeOnConsentOrder">
         <inputExpression id="LiteralExpression_00u1rae" typeRef="boolean">
           <text>if(additionalData.Data.generalAppConsentOrder != null and additionalData.Data.judicialDecision != null) then true else false</text>
         </inputExpression>
@@ -2048,7 +2048,7 @@ else false</text>
           <text>"LegalAdvisorRevisitApplication"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1pjqzfu">
-          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_14q6s85">
           <text></text>
@@ -2142,7 +2142,7 @@ else false</text>
           <text>"LegalAdvisorRevisitApplication"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0c3fri3">
-          <text>"lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))"</text>
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1mwyk2c">
           <text></text>
@@ -2236,7 +2236,7 @@ else false</text>
           <text>"LegalAdvisorRevisitApplication"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_03ltfhw">
-          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1m37qyx">
           <text></text>
@@ -2330,7 +2330,7 @@ else false</text>
           <text>"LegalAdvisorRevisitApplication"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1gqs3d0">
-          <text>"lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))"</text>
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0lmcaeg">
           <text></text>

--- a/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
@@ -62,11 +62,6 @@ or list contains(additionalData.Data.generalAppType.types, "OTHER"))) then false
 else if (additionalData.Data.generalAppConsentOrder != null ) then true else false</text>
         </inputExpression>
       </input>
-      <input id="InputClause_0u992iu" label="isDecisionAlreadyMadeOnConsentOrder">
-        <inputExpression id="LiteralExpression_1vknzov" typeRef="boolean">
-          <text>if(additionalData.Data.generalAppConsentOrder != null) &amp;&amp; (additionalData.Data.judicialDecision!= null)</text>
-        </inputExpression>
-      </input>
       <input id="InputClause_1s4wp88" label="isAlreadyReferedToJudge">
         <inputExpression id="LiteralExpression_0xukk5x" typeRef="boolean">
           <text>if(additionalData.Data.referToJudge!= null) then true
@@ -85,7 +80,7 @@ else false</text>
       <output id="OutputClause_1o4gc2a" label="Process Categories Identifiers" name="processCategories" typeRef="string" />
       <rule id="DecisionRule_046gs9f">
         <inputEntry id="UnaryTests_1xolm0z">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0j3x4bw">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -108,9 +103,6 @@ else false</text>
         <inputEntry id="UnaryTests_0oecj2r">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1masw8n">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1wtwdv7">
           <text></text>
         </inputEntry>
@@ -132,7 +124,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_167rsam">
         <inputEntry id="UnaryTests_0b2bxqj">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0he81p8">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -155,9 +147,6 @@ else false</text>
         <inputEntry id="UnaryTests_0ynqp6p">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1f7w9zs">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_0u4bte5">
           <text></text>
         </inputEntry>
@@ -179,7 +168,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_0rt9dst">
         <inputEntry id="UnaryTests_0fwhfrt">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_01y87ki">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -202,9 +191,6 @@ else false</text>
         <inputEntry id="UnaryTests_0gnvjbg">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1rh87gn">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_0spvc5y">
           <text></text>
         </inputEntry>
@@ -226,7 +212,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_02cq4n1">
         <inputEntry id="UnaryTests_04f3dej">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0ycpwh3">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -249,9 +235,6 @@ else false</text>
         <inputEntry id="UnaryTests_0860y5x">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1878qrn">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1a4sy6m">
           <text></text>
         </inputEntry>
@@ -268,382 +251,6 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_17zwv52">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_1w1cac2">
-        <inputEntry id="UnaryTests_1saj8s1">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_15a7tgl">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0g27ptb">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0rj46o7">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1jxc1k0">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0kv1gj2">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_13s9qkg">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1hy2360">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1akdjew">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_01jnovl">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_06fxa3k">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1pl0sou">
-          <text>"JudgeDecideOnApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0aj7agt">
-          <text>"Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0wcgs5y">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1k7byg3">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0ntwnuc">
-        <inputEntry id="UnaryTests_0qg96cv">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0689l05">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1yvz5wq">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1xs90x1">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1qny128">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1c5l2if">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_003kagf">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1x5vk3h">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0dw2ttt">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0pgxf4e">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1628s86">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_0h9x0se">
-          <text>"JudgeRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_04lpbwk">
-          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0nvs4fq">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1yqrodj">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0wgu1pf">
-        <inputEntry id="UnaryTests_1iwjg2f">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0yobwjc">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_18x8dth">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0wq3o6y">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1xf0s0g">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_05u8fml">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1xtv4zj">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1y5pho5">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1bojlzk">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1qdscj2">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1prus48">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_179itoz">
-          <text>"JudgeDecideOnApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_10dpok8">
-          <text>"Application for multiple types"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0brdvo0">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_02xfvs5">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_033g5k9">
-        <inputEntry id="UnaryTests_0fvwodc">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1mqqtqr">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1ggtes4">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_12i0z59">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1c0vt69">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0fhss09">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1clxdx9">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1oqy8d9">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_12t1gp8">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_19b2v7n">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1vhcx3f">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1wp43zk">
-          <text>"JudgeRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_09vi5xd">
-          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_109d7fu">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_04p83bd">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_1mkmryy">
-        <inputEntry id="UnaryTests_05uhw5g">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1ozm0ff">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_17f3d3q">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0zkfi5n">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_18lg0ir">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0rwo5ar">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0qj4u1h">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_018k73m">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0o78qbk">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_178mmn8">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1itxkqj">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_0rct2y3">
-          <text>"JudgeDecideOnApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1whxmif">
-          <text> "Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_13d4sp5">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1qfnp6g">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0ih0ywu">
-        <inputEntry id="UnaryTests_044khxg">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0es9ncr">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0ilihd9">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_026hqij">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_03964d6">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0o99nsg">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_01um4f4">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1o032c2">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_17wicy5">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0n301in">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1vxpn3j">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_0dtx870">
-          <text>"JudgeRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0pd1edb">
-          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0qcqyd6">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0a2gg4b">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_1necgwe">
-        <inputEntry id="UnaryTests_06tvog6">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_199keqd">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0umejfc">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1a0jjpo">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_00434e9">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1q97jpt">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1tbyfyp">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_01pqitl">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0e674eo">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_15vieko">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_18c7sxl">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_09ggf15">
-          <text>"JudgeDecideOnApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0n6x723">
-          <text>"Application for multiple types"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0ee2qlz">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1hze6vr">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_1qjjm8h">
-        <inputEntry id="UnaryTests_0hs28yv">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1m0cvv0">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1krqldd">
-          <text>-</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0kvwwac">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0sp1vg0">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_09it83z">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1kk7yz2">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1dnqvym">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1ygtmq0">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0hwdtqb">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1h9cmq0">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1rn8u06">
-          <text>"JudgeRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_13o65ra">
-          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_06im13l">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_08vzyta">
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
@@ -671,9 +278,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0b1mcb9">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_01zzqbx">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0ww4l56">
           <text></text>
@@ -719,9 +323,6 @@ else false</text>
         <inputEntry id="UnaryTests_1axg4dz">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1ozqxq1">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1nrxaz8">
           <text></text>
         </inputEntry>
@@ -765,9 +366,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0xa66oj">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0mcnsgu">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_113nqz0">
           <text></text>
@@ -813,9 +411,6 @@ else false</text>
         <inputEntry id="UnaryTests_1nv3zb5">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_000csea">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_0vev614">
           <text></text>
         </inputEntry>
@@ -859,9 +454,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0rfbpao">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1ibbhy0">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0uwh4yo">
           <text></text>
@@ -907,9 +499,6 @@ else false</text>
         <inputEntry id="UnaryTests_1kw60fr">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_0u2nmd3">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1vlivok">
           <text></text>
         </inputEntry>
@@ -953,9 +542,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_02qntb0">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0uidsrl">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1642wcy">
           <text></text>
@@ -1001,9 +587,6 @@ else false</text>
         <inputEntry id="UnaryTests_19b1bck">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_18at8r0">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_084whfm">
           <text></text>
         </inputEntry>
@@ -1047,9 +630,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ca09d2">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1imkero">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0jijl19">
           <text></text>
@@ -1095,9 +675,6 @@ else false</text>
         <inputEntry id="UnaryTests_02b2hh8">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1ov7p62">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_0w095sa">
           <text></text>
         </inputEntry>
@@ -1141,9 +718,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1wozqed">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1ngjbk8">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_08j1mb9">
           <text></text>
@@ -1189,9 +763,6 @@ else false</text>
         <inputEntry id="UnaryTests_11mdgyi">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_0jono2a">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_14x9h9t">
           <text></text>
         </inputEntry>
@@ -1213,7 +784,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_0jncb6o">
         <inputEntry id="UnaryTests_0l5mxjf">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_059j2hq">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -1236,9 +807,6 @@ else false</text>
         <inputEntry id="UnaryTests_1n83kdv">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_0ln658b">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1v096uc">
           <text></text>
         </inputEntry>
@@ -1260,7 +828,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_0h6xns3">
         <inputEntry id="UnaryTests_1x9zmtc">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0jmntdn">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -1283,9 +851,6 @@ else false</text>
         <inputEntry id="UnaryTests_1ob30il">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1vk8r5l">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_00i9b3q">
           <text></text>
         </inputEntry>
@@ -1307,7 +872,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_0fsu84p">
         <inputEntry id="UnaryTests_08wuxd5">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1vqghb0">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -1330,9 +895,6 @@ else false</text>
         <inputEntry id="UnaryTests_1jxo8qd">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1qe23bi">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_12lp4i1">
           <text></text>
         </inputEntry>
@@ -1354,7 +916,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_11w0wxf">
         <inputEntry id="UnaryTests_1mmwt6s">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_023wybc">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -1377,9 +939,6 @@ else false</text>
         <inputEntry id="UnaryTests_0bhn0wf">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_0vqfuvv">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1f2zpq2">
           <text></text>
         </inputEntry>
@@ -1396,382 +955,6 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1yuoynr">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0b5s8pt">
-        <inputEntry id="UnaryTests_1x8x8sz">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0cy3alr">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0n7dx33">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0v07b8x">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1y10oh2">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_01ojtnp">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0azq6v4">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_13virrv">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1a6tv19">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1dlg7ph">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_017pnz9">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1tylsrg">
-          <text>"JudgeDecideOnApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0u96mf8">
-          <text>"Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0xta78m">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1pajltk">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0h1hdro">
-        <inputEntry id="UnaryTests_1h0bpvf">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0o8k13a">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_18xllfv">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0q6br30">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1mwv9d2">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0sb3gx1">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_051ih1d">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0tzuhz8">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1099jn3">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_16l9k8y">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1k9807h">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_052fz2w">
-          <text>"JudgeRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0c262ra">
-          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1gwbsv8">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1jyqtq4">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0anmnel">
-        <inputEntry id="UnaryTests_0xb76y9">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0eictgy">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1vzf9pc">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0zxa54p">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0wnag2z">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_14gcq1u">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1o14shf">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0w09q3e">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0vdiw89">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_17dm4bh">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1kcqyll">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1ary9mw">
-          <text>"JudgeDecideOnApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0xvrfd4">
-          <text>"Application for multiple types"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_178pojr">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0y8gdx5">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_1idgxio">
-        <inputEntry id="UnaryTests_0xja5hw">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1rptf9t">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0ilqpsq">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1iphjod">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0p4vvjw">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0j6zh3h">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_11ttssi">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_14axqaa">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_19n8wa4">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0dxvy3x">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0hox3s5">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_0dpedoe">
-          <text>"JudgeRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0su8uan">
-          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_13wh8t4">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_01dzd3z">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_1m15oxx">
-        <inputEntry id="UnaryTests_01b9lcg">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0252ig8">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0p051jy">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_006pi2h">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0kahryr">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0gqttu2">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_12hepro">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1i6nv7n">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0r2neas">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_07ra2l0">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1ga3hmg">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_09w4yf2">
-          <text>"JudgeDecideOnApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1t3p0jj">
-          <text> "Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1f11xvr">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0gys0ef">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0cxyvsz">
-        <inputEntry id="UnaryTests_1812gan">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_065zf6b">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_09zct5e">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_11pkx4d">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0gc2gno">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0pjd3v4">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_17nebjv">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1ulz6lx">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0tusy1n">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0b0wgbw">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1qb65ti">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_0n3a59v">
-          <text>"JudgeRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0a5tall">
-          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1u7wzqh">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0ght8w6">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0gfvykz">
-        <inputEntry id="UnaryTests_1gc62pu">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_09xuj1q">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1c6umrf">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_12vbucs">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_04dygej">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1c3lgby">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_17c3qua">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1jm4lup">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1gx42xi">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0iy8mml">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1urgczv">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_0cxaotk">
-          <text>"JudgeDecideOnApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1ev5jbh">
-          <text>"Application for multiple types"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_003hocy">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1tkgl2a">
-          <text>"generalApplications"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_01hfrig">
-        <inputEntry id="UnaryTests_0rurqw9">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1mr2cow">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_12u9ma4">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1a4jaky">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1e7i9cz">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0yv35iy">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0z2501x">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0qsdb36">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0ybsvbp">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0pd9qcz">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1c36rjy">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_0mtruyy">
-          <text>"JudgeRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1cuyksx">
-          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_01nt01q">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0je33e4">
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
@@ -1799,9 +982,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1mnixvx">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1i4sbt3">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_193dfzw">
           <text></text>
@@ -1847,9 +1027,6 @@ else false</text>
         <inputEntry id="UnaryTests_1nocxyu">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_0ad3rev">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1vi13vr">
           <text></text>
         </inputEntry>
@@ -1893,9 +1070,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_098s97s">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_15mp6xm">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0txt1on">
           <text></text>
@@ -1941,9 +1115,6 @@ else false</text>
         <inputEntry id="UnaryTests_0nlhqqq">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1i49u9v">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1n3l5rq">
           <text></text>
         </inputEntry>
@@ -1987,9 +1158,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0b9l26t">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_19v83y0">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1bmclva">
           <text></text>
@@ -2035,9 +1203,6 @@ else false</text>
         <inputEntry id="UnaryTests_0eu4g7d">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1gvl3mm">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_0oc7z1h">
           <text></text>
         </inputEntry>
@@ -2081,9 +1246,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_00ni92y">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1ajua3f">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_09dn1rp">
           <text></text>
@@ -2129,9 +1291,6 @@ else false</text>
         <inputEntry id="UnaryTests_1i3vkpo">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_0k9g3ez">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1a76uxh">
           <text></text>
         </inputEntry>
@@ -2175,9 +1334,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0ool9cq">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1mb75jp">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0lex4u3">
           <text></text>
@@ -2223,9 +1379,6 @@ else false</text>
         <inputEntry id="UnaryTests_0on9sli">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_07p82xl">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_0zrgc0z">
           <text></text>
         </inputEntry>
@@ -2269,9 +1422,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_07ryt8f">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1ol3enm">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0qw3od0">
           <text></text>
@@ -2317,9 +1467,6 @@ else false</text>
         <inputEntry id="UnaryTests_06lvzet">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_0thzum6">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_161bk9e">
           <text></text>
         </inputEntry>
@@ -2339,103 +1486,9 @@ else false</text>
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
-      <rule id="DecisionRule_0n371xx">
-        <inputEntry id="UnaryTests_15syb8q">
-          <text>"END_BUSINESS_PROCESS_GASPEC"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0rbr0i9">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0qnloxg">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0fb0gdn">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1gou5qt">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_08del9g">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0u2zgm4">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_11i3x3n">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0k72egq">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0ta4n2b">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0e5jq2s">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1i1ddux">
-          <text>"LegalAdvisorDecideOnApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0zq30jd">
-          <text>"Application for multiple types"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1q20i5k">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_001ncrx">
-          <text>"generalApplicationsBeforeSdo"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_1502jbn">
-        <inputEntry id="UnaryTests_05ixcd6">
-          <text>"END_BUSINESS_PROCESS_GASPEC"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1m2y5ki">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0ipgzan">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1p8w8f3">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0psrx72">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_15xx5bh">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1d4zfj1">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1yvjg00">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1ky1j2n">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_16v9cm2">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1y8a4n0">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1ms199v">
-          <text>"LegalAdvisorDecideOnApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_086uu97">
-          <text> "Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1xrj70s">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0562dm9">
-          <text>"generalApplicationsBeforeSdo"</text>
-        </outputEntry>
-      </rule>
       <rule id="DecisionRule_1aoortf">
         <inputEntry id="UnaryTests_03awqgl">
-          <text>"END_BUSINESS_PROCESS_GASPEC"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1gaqlxp">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -2458,9 +1511,6 @@ else false</text>
         <inputEntry id="UnaryTests_1pzycwi">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_0tquy7z">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1ux63ok">
           <text></text>
         </inputEntry>
@@ -2480,9 +1530,97 @@ else false</text>
           <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_0n371xx">
+        <inputEntry id="UnaryTests_15syb8q">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0rbr0i9">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qnloxg">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fb0gdn">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1gou5qt">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_08del9g">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0u2zgm4">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11i3x3n">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ta4n2b">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0e5jq2s">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1i1ddux">
+          <text>"LegalAdvisorDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0zq30jd">
+          <text>"Application for multiple types"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1q20i5k">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_001ncrx">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1502jbn">
+        <inputEntry id="UnaryTests_05ixcd6">
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1m2y5ki">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ipgzan">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1p8w8f3">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0psrx72">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15xx5bh">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1d4zfj1">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yvjg00">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16v9cm2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1y8a4n0">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1ms199v">
+          <text>"LegalAdvisorDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_086uu97">
+          <text> "Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1xrj70s">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0562dm9">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_0zdezfb">
         <inputEntry id="UnaryTests_1m1qxfg">
-          <text>"END_BUSINESS_PROCESS_GASPEC"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_11803rc">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -2505,9 +1643,6 @@ else false</text>
         <inputEntry id="UnaryTests_0ju2tv3">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1blgbw9">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_18v3sz8">
           <text></text>
         </inputEntry>
@@ -2524,382 +1659,6 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0quqdhw">
-          <text>"generalApplicationsBeforeSdo"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0vz6qq0">
-        <inputEntry id="UnaryTests_1ho86ro">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0acjcng">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1ggoi40">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1feywep">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_18d37fb">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1afnrvm">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0at49vj">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0l7byqv">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1933lrz">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1yj5gm8">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_106mll9">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_03b7546">
-          <text>"LegalAdvisorDecideOnApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0p5q5q2">
-          <text>"Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_15ij7bk">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1bdmmav">
-          <text>"generalApplicationsBeforeSdo"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0c8i4x2">
-        <inputEntry id="UnaryTests_1vfk6e4">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1c1wv1q">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_086882w">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0hk6468">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1beou89">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0vkw0v7">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_07rfexx">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1gyv6s2">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0mypd8x">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0royraa">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_13pf02y">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_0vgtuov">
-          <text>"LegalAdvisorRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0v49pkm">
-          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0w3hwkb">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1be1rn9">
-          <text>"generalApplicationsBeforeSdo"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0gy6ddg">
-        <inputEntry id="UnaryTests_1o6upq5">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0hvi46k">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1pd1kgu">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_198zfs2">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0gg05tf">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1oeukv4">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1mtbkta">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1s9gm7t">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0t1akm0">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0tiq95y">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_026ef3o">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_0xjfrjn">
-          <text>"LegalAdvisorDecideOnApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0sb5ovd">
-          <text>"Application for multiple types"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_00ufzxo">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1y7y8vc">
-          <text>"generalApplicationsBeforeSdo"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_15zujzm">
-        <inputEntry id="UnaryTests_1c68hdt">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1h9lh7g">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1latxz9">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0ajy6oe">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0s1m949">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0k4em6q">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1sw3ny8">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0ecy7wg">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_08bh58n">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_17utau5">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1s4sedl">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_0fhjv7n">
-          <text>"LegalAdvisorRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0i1rsa8">
-          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0u81wm0">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1uzm7ge">
-          <text>"generalApplicationsBeforeSdo"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_1e5jskc">
-        <inputEntry id="UnaryTests_06du8cp">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1jz6ruw">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0041o2u">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0jrs9qd">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0bhdim1">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0i63ow7">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_16cv1h3">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0022j0b">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1x3sdhb">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0xrzhd8">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0qdqmhf">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1j04kw4">
-          <text>"LegalAdvisorDecideOnApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0z9xvzw">
-          <text> "Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0fyln91">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0qis766">
-          <text>"generalApplicationsBeforeSdo"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0diarj7">
-        <inputEntry id="UnaryTests_0wxxbyw">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1rq62s3">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1eocoqr">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1k0i3ya">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1vmit0e">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0hlsuwe">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0atpx49">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1w673ll">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0xylg36">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1p01rcr">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0t6540x">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_020lly5">
-          <text>"LegalAdvisorRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1b67jgj">
-          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_07cnl0e">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0ihlp57">
-          <text>"generalApplicationsBeforeSdo"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_1h3s56j">
-        <inputEntry id="UnaryTests_0dlm7px">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0o9jvdh">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_088iry9">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_13w1a48">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0qr6e1v">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_04ojsjh">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1cwp3wo">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_02e0xcg">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_13rjqwt">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0pzujyb">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0qkyc33">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_189rqcf">
-          <text>"LegalAdvisorDecideOnApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0j54nbj">
-          <text>"Application for multiple types"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0b1sl6p">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1q74zxa">
-          <text>"generalApplicationsBeforeSdo"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_14pycrj">
-        <inputEntry id="UnaryTests_0rdba2h">
-          <text>"RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0sjhawf">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1xbfwnj">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1cu0bjm">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_107guos">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0oeoo4h">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_00jk0k9">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1jy1kob">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1oxcxze">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0qh74af">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0k36gnu">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1tq3c1f">
-          <text>"LegalAdvisorRevisitApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1xmwp4d">
-          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0t6n6a5">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1uwg83n">
           <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
@@ -2927,9 +1686,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0syvzhl">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0cgysd0">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ti3033">
           <text></text>
@@ -2975,9 +1731,6 @@ else false</text>
         <inputEntry id="UnaryTests_0r0pl1q">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1k0mw0o">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_04vu6po">
           <text></text>
         </inputEntry>
@@ -3021,9 +1774,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0jxjecy">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_06qmhk0">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0w0hgdm">
           <text></text>
@@ -3069,9 +1819,6 @@ else false</text>
         <inputEntry id="UnaryTests_1d7iegw">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1143lxd">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_10hrp0l">
           <text></text>
         </inputEntry>
@@ -3115,9 +1862,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0nwnvhj">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0589e4l">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_165uwx9">
           <text></text>
@@ -3163,9 +1907,6 @@ else false</text>
         <inputEntry id="UnaryTests_09drgg4">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_0jdy04x">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_0f7b5a4">
           <text></text>
         </inputEntry>
@@ -3209,9 +1950,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_090vkn1">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0x7beyx">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1wj5umc">
           <text></text>
@@ -3257,9 +1995,6 @@ else false</text>
         <inputEntry id="UnaryTests_1q938s7">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1d3efrp">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_18wiqty">
           <text></text>
         </inputEntry>
@@ -3303,9 +2038,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1k32t4w">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1pwdrfr">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0zsjyed">
           <text></text>
@@ -3351,9 +2083,6 @@ else false</text>
         <inputEntry id="UnaryTests_1gh2plu">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_075z7lb">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_0528mnx">
           <text></text>
         </inputEntry>
@@ -3397,9 +2126,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1k9e9x2">
           <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0tq0v4p">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1alwf4v">
           <text></text>
@@ -3445,9 +2171,6 @@ else false</text>
         <inputEntry id="UnaryTests_0sm1dn8">
           <text>false</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1xj303e">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1mej8t8">
           <text></text>
         </inputEntry>
@@ -3491,9 +2214,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_10nhxqs">
           <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_13lf63i">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0o57zfw">
           <text></text>
@@ -3539,9 +2259,6 @@ else false</text>
         <inputEntry id="UnaryTests_1ur1rh5">
           <text>true</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_17lor3c">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_06dzeuj">
           <text></text>
         </inputEntry>
@@ -3585,9 +2302,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0oro08q">
           <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0qkyki9">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0bx2c5r">
           <text></text>
@@ -3633,9 +2347,6 @@ else false</text>
         <inputEntry id="UnaryTests_0gkzm4q">
           <text>true</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1ydh4fj">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_0ope7wa">
           <text></text>
         </inputEntry>
@@ -3679,9 +2390,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_021xvdp">
           <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1tfkcxm">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_11944md">
           <text></text>
@@ -3727,9 +2435,6 @@ else false</text>
         <inputEntry id="UnaryTests_1dpfvej">
           <text>true</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_0i30cwy">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_0919haa">
           <text></text>
         </inputEntry>
@@ -3773,9 +2478,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0plwt4o">
           <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1g2jlut">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1qfh7tr">
           <text></text>
@@ -3821,9 +2523,6 @@ else false</text>
         <inputEntry id="UnaryTests_1bv1bmj">
           <text>true</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1swkmu5">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1crlhit">
           <text></text>
         </inputEntry>
@@ -3867,9 +2566,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1s9ys7j">
           <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0ncd2jg">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_147ktb0">
           <text></text>
@@ -3915,9 +2611,6 @@ else false</text>
         <inputEntry id="UnaryTests_0pbf8iy">
           <text>true</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_06a0nnm">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1qtkpf1">
           <text></text>
         </inputEntry>
@@ -3961,9 +2654,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0ok14tu">
           <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_18pneqn">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_04ikap8">
           <text></text>
@@ -4009,9 +2699,6 @@ else false</text>
         <inputEntry id="UnaryTests_1f5lrsk">
           <text>true</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_07dx23h">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1jh5tkn">
           <text></text>
         </inputEntry>
@@ -4055,9 +2742,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_15rg2rj">
           <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1q3z849">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1rm4olm">
           <text></text>
@@ -4103,9 +2787,6 @@ else false</text>
         <inputEntry id="UnaryTests_0qu3ew4">
           <text>true</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_199utg9">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_18nofkx">
           <text></text>
         </inputEntry>
@@ -4149,9 +2830,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0lkby76">
           <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1vf5ldo">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_05u0u0k">
           <text></text>
@@ -4197,9 +2875,6 @@ else false</text>
         <inputEntry id="UnaryTests_1tw5cms">
           <text>true</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1kzcjbf">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_02j2kxe">
           <text></text>
         </inputEntry>
@@ -4243,9 +2918,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0hl4vh6">
           <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1fe1iog">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0s36l3a">
           <text>true</text>
@@ -4291,9 +2963,6 @@ else false</text>
         <inputEntry id="UnaryTests_0dh6rq2">
           <text>true</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_03hktlh">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_0k7qcbu">
           <text>true</text>
         </inputEntry>
@@ -4337,9 +3006,6 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_19o7vb8">
           <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0r9cfx7">
-          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1sw0h6f">
           <text>false</text>
@@ -4385,9 +3051,6 @@ else false</text>
         <inputEntry id="UnaryTests_1qerixt">
           <text>true</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1egso69">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1bgzh1a">
           <text>false</text>
         </inputEntry>
@@ -4430,9 +3093,6 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1mw376f">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0tr9nfk">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0zpym82">
@@ -4479,9 +3139,6 @@ else false</text>
         <inputEntry id="UnaryTests_00mjp2t">
           <text></text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1kps289">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_14aqlwq">
           <text></text>
         </inputEntry>
@@ -4524,9 +3181,6 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_13tb2iv">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0pct0nv">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_12gi93k">
@@ -4573,9 +3227,6 @@ else false</text>
         <inputEntry id="UnaryTests_0j24wpm">
           <text></text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1xfb50r">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1h5t43b">
           <text></text>
         </inputEntry>
@@ -4618,9 +3269,6 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1qqsirc">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0zcmwzd">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0z3zisk">
@@ -4667,9 +3315,6 @@ else false</text>
         <inputEntry id="UnaryTests_1japzxm">
           <text></text>
         </inputEntry>
-        <inputEntry id="UnaryTests_0axcrkb">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1wpsfdc">
           <text></text>
         </inputEntry>
@@ -4712,9 +3357,6 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0hzsq1i">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1jqssar">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_03azrte">
@@ -4761,9 +3403,6 @@ else false</text>
         <inputEntry id="UnaryTests_1dzx7ph">
           <text></text>
         </inputEntry>
-        <inputEntry id="UnaryTests_00j8jvy">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1wtezix">
           <text></text>
         </inputEntry>
@@ -4806,9 +3445,6 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ii8lzs">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_10owo4x">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_10223wl">
@@ -4855,9 +3491,6 @@ else false</text>
         <inputEntry id="UnaryTests_086yycn">
           <text></text>
         </inputEntry>
-        <inputEntry id="UnaryTests_0ys5rdq">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1vuhmt9">
           <text></text>
         </inputEntry>
@@ -4900,9 +3533,6 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0zwlkzn">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0nvnge3">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1akl7uc">
@@ -4949,9 +3579,6 @@ else false</text>
         <inputEntry id="UnaryTests_1c0evmr">
           <text></text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1grub1g">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_05pg0nl">
           <text></text>
         </inputEntry>
@@ -4994,9 +3621,6 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0gdzf2a">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_08o0tuu">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1iklz03">
@@ -5043,9 +3667,6 @@ else false</text>
         <inputEntry id="UnaryTests_1p5fl06">
           <text></text>
         </inputEntry>
-        <inputEntry id="UnaryTests_13vtbzo">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1dthdza">
           <text></text>
         </inputEntry>
@@ -5090,9 +3711,6 @@ else false</text>
         <inputEntry id="UnaryTests_1l7veu4">
           <text>-</text>
         </inputEntry>
-        <inputEntry id="UnaryTests_0io3bno">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_0avxtni">
           <text></text>
         </inputEntry>
@@ -5135,9 +3753,6 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0jv449h">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0khbncq">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0rpwzgr">
@@ -5184,9 +3799,6 @@ else false</text>
         <inputEntry id="UnaryTests_02m6vo1">
           <text></text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1plvwsp">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1jq8fta">
           <text></text>
         </inputEntry>
@@ -5229,9 +3841,6 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_063svbt">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0a3vy6j">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1fsbtio">
@@ -5278,9 +3887,6 @@ else false</text>
         <inputEntry id="UnaryTests_0m1meou">
           <text></text>
         </inputEntry>
-        <inputEntry id="UnaryTests_0u2kysd">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_02f9v27">
           <text></text>
         </inputEntry>
@@ -5323,9 +3929,6 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ai2d2d">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1uk7srl">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1vyzqz0">
@@ -5372,9 +3975,6 @@ else false</text>
         <inputEntry id="UnaryTests_1cvbrze">
           <text></text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1c16vjl">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1m7339v">
           <text></text>
         </inputEntry>
@@ -5417,9 +4017,6 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ahyxn9">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1f4nf4r">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_17mujco">
@@ -5466,9 +4063,6 @@ else false</text>
         <inputEntry id="UnaryTests_0igf5h7">
           <text></text>
         </inputEntry>
-        <inputEntry id="UnaryTests_1nii5tj">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1ar78ai">
           <text></text>
         </inputEntry>
@@ -5511,9 +4105,6 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0jtpsxa">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0cywaa9">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0t1vxqe">
@@ -5560,9 +4151,6 @@ else false</text>
         <inputEntry id="UnaryTests_0b4m0ua">
           <text></text>
         </inputEntry>
-        <inputEntry id="UnaryTests_07dmhju">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_08ko5eb">
           <text></text>
         </inputEntry>
@@ -5605,9 +4193,6 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1h0yz3c">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0wvuod0">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_16b4vfh">
@@ -5654,9 +4239,6 @@ else false</text>
         <inputEntry id="UnaryTests_0dpqy55">
           <text></text>
         </inputEntry>
-        <inputEntry id="UnaryTests_0k9yv7t">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_0x71sse">
           <text></text>
         </inputEntry>
@@ -5699,9 +4281,6 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0vxvk6s">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0gza5ce">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ynots6">
@@ -5748,9 +4327,6 @@ else false</text>
         <inputEntry id="UnaryTests_1h1jqt7">
           <text></text>
         </inputEntry>
-        <inputEntry id="UnaryTests_0tip24v">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_06ukd0b">
           <text></text>
         </inputEntry>
@@ -5793,9 +4369,6 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0dwtrqe">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1brco4w">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0ay909n">
@@ -5844,9 +4417,6 @@ else false</text>
         <inputEntry id="UnaryTests_1gijj60">
           <text></text>
         </inputEntry>
-        <inputEntry id="UnaryTests_0nq5onz">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_0cqds7h">
           <text></text>
         </inputEntry>
@@ -5893,9 +4463,6 @@ else false</text>
         <inputEntry id="UnaryTests_0e4unxx">
           <text></text>
         </inputEntry>
-        <inputEntry id="UnaryTests_16td43v">
-          <text></text>
-        </inputEntry>
         <inputEntry id="UnaryTests_1bmbh5w">
           <text></text>
         </inputEntry>
@@ -5938,9 +4505,6 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_067j89w">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_19te4ew">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1398lbx">

--- a/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
@@ -2947,7 +2947,7 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1gz0bqk">
-          <text>"generalApplicationsBeforeSdo"</text>
+          <text>"generalApplications"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0fkf1zq">
@@ -2994,7 +2994,7 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0vnpvta">
-          <text>"generalApplicationsBeforeSdo"</text>
+          <text>"generalApplications"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0qi7mo1">
@@ -3041,7 +3041,7 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0jvcy0c">
-          <text>"generalApplicationsBeforeSdo"</text>
+          <text>"generalApplications"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0aqx029">
@@ -3088,7 +3088,7 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_032yb06">
-          <text>"generalApplicationsBeforeSdo"</text>
+          <text>"generalApplications"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0c0oi8c">
@@ -3135,7 +3135,7 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1be6vjw">
-          <text>"generalApplicationsBeforeSdo"</text>
+          <text>"generalApplications"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0sav2df">
@@ -3182,7 +3182,7 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0b72p8l">
-          <text>"generalApplicationsBeforeSdo"</text>
+          <text>"generalApplications"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0z3g8d6">
@@ -3229,7 +3229,7 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1dcphqp">
-          <text>"generalApplicationsBeforeSdo"</text>
+          <text>"generalApplications"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_168c020">
@@ -3276,7 +3276,7 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0wuah36">
-          <text>"generalApplicationsBeforeSdo"</text>
+          <text>"generalApplications"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1bajgt6">
@@ -3751,7 +3751,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_12m3o4x">
         <inputEntry id="UnaryTests_0h7lbbo">
-          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID","TRIGGER_LOCATION_UPDATE"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0o75mk8">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -3798,7 +3798,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_0uqjujy">
         <inputEntry id="UnaryTests_1lwr8v9">
-          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID","TRIGGER_LOCATION_UPDATE"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0mvh3e9">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -3939,7 +3939,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_0u202ni">
         <inputEntry id="UnaryTests_042br0h">
-          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID","TRIGGER_LOCATION_UPDATE"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_16903hu">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -3986,7 +3986,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_131yozd">
         <inputEntry id="UnaryTests_1d84k22">
-          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID","TRIGGER_LOCATION_UPDATE"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_15753qf">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -4127,7 +4127,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_0g5vsnt">
         <inputEntry id="UnaryTests_175oo46">
-          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID","TRIGGER_LOCATION_UPDATE"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0qed6ep">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -4174,7 +4174,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_0vzvnc4">
         <inputEntry id="UnaryTests_04n1656">
-          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID","TRIGGER_LOCATION_UPDATE"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_099q67l">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -4315,7 +4315,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_1m1h38d">
         <inputEntry id="UnaryTests_0il43fm">
-          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID","TRIGGER_LOCATION_UPDATE"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0rn0d7o">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -4362,7 +4362,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_1z03ev4">
         <inputEntry id="UnaryTests_1bg9f78">
-          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION","MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID","TRIGGER_LOCATION_UPDATE"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1c9iuk2">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>

--- a/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
@@ -606,6 +606,182 @@ else false</text>
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_1om3w4g">
+        <inputEntry id="UnaryTests_0s8weuv">
+          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17t33kk">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1gfaiez">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yn30t9">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ni9hrq">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fulv8e">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11ozh57">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ca09d2">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0jijl19">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0dgpzkb">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0smcpny">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0u3yupn">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_16x1w62">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1mopq28">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0x5hxn1">
+        <inputEntry id="UnaryTests_0t34x14">
+          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hd3xmv">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uvi86j">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ftlxds">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1dcl1oq">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1dye3ra">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0guizd1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_02b2hh8">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0w095sa">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_00g6vi3">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_02hh205">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0sxly07">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_060lv0c">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_08eammb">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0cy9vz7">
+        <inputEntry id="UnaryTests_1dki416">
+          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0msixly">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0p4no4c">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0c4qlut">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13l38vp">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1cce3xi">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15nmkxu">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1wozqed">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_08j1mb9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05au76f">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1cw3ab8">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1cj2612">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_099o0av">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1n0j0j8">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0iciiwm">
+        <inputEntry id="UnaryTests_01t8pza">
+          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jlyvtz">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1iwih02">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0eso8xm">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1gw75je">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wsrb6r">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_08ces6d">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11mdgyi">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14x9h9t">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01tx23j">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19ygkcm">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0pbbi01">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1nxz4pn">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0wfiphi">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_0jncb6o">
         <inputEntry id="UnaryTests_0l5mxjf">
           <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
@@ -1134,6 +1310,182 @@ else false</text>
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_0s7bo38">
+        <inputEntry id="UnaryTests_1qa5u02">
+          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zxy6tf">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0y5c1lm">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1lsebqv">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0a9bbe2">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11zmuzk">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1gktnlj">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ool9cq">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lex4u3">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1skfccb">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_043uk1e">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_02sgcw2">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0jqfy3y">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_004r298">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1njyz15">
+        <inputEntry id="UnaryTests_1wfsbr4">
+          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xvqxsk">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_00guxpi">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ztuden">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1byvg7q">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0s2q4ag">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0stmbbn">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0on9sli">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zrgc0z">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16rfym6">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0jyofem">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1c7z1zc">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_08eqtt8">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0cogv02">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_09b02gv">
+        <inputEntry id="UnaryTests_18yw5v2">
+          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zoatrl">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pghktp">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1m568kb">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03efs9r">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1quz8qc">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1nrv7qr">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_07ryt8f">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qw3od0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0s8o6y3">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0cteh7i">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0yu369x">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0hsj6pz">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ophxsg">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0dje00o">
+        <inputEntry id="UnaryTests_0vgrazn">
+          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19gf83m">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1i5pwyn">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1wzeo4y">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0j8dnds">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0k6oa23">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14k1ngq">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06lvzet">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_161bk9e">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03ru0ai">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0r0daim">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1c0c9l3">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0h6s8gc">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0jdumzg">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_1aoortf">
         <inputEntry id="UnaryTests_03awqgl">
           <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
@@ -1659,6 +2011,182 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_01zfgps">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_14ube0j">
+        <inputEntry id="UnaryTests_1mhbw1l">
+          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ia990o">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0iun4cr">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0eiaew2">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1e89wta">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1wk4fcs">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16b02d1">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1k32t4w">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zsjyed">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0jexo8e">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_07iwblv">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_160r2lx">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1kglizs">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1defb56">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1pzr58d">
+        <inputEntry id="UnaryTests_159nam7">
+          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0mis1yw">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1cssac3">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19z2teo">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0sdz1do">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05i5c99">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1an8fxt">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1gh2plu">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0528mnx">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jec58j">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_01uoy28">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1lsssyn">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0qtu6b6">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0i4kzf1">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_087bdep">
+        <inputEntry id="UnaryTests_055n1r2">
+          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1cecg9v">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17c0uwp">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_178vye6">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1m8ih7s">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1hr55bi">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1dqhnmi">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1k9e9x2">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1alwf4v">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1swr5f4">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0i71pnn">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1grxz6i">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1t4mysl">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0inttxw">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0o8ihs1">
+        <inputEntry id="UnaryTests_1y17695">
+          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ke99gi">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1sawcxk">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17lwcvr">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_196koeo">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1kc2quh">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1gnvl3t">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0sm1dn8">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mej8t8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0syz61r">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0wmsan1">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1b94hlq">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_024aw3i">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0m942ww">
           <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>

--- a/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
@@ -62,6 +62,11 @@ or list contains(additionalData.Data.generalAppType.types, "OTHER"))) then false
 else if (additionalData.Data.generalAppConsentOrder != null ) then true else false</text>
         </inputExpression>
       </input>
+      <input id="InputClause_0u992iu" label="isDecisionAlreadyMadeOnConsentOrder">
+        <inputExpression id="LiteralExpression_1vknzov" typeRef="boolean">
+          <text>if(additionalData.Data.generalAppConsentOrder != null) &amp;&amp; (additionalData.Data.judicialDecision!= null)</text>
+        </inputExpression>
+      </input>
       <input id="InputClause_1s4wp88" label="isAlreadyReferedToJudge">
         <inputExpression id="LiteralExpression_0xukk5x" typeRef="boolean">
           <text>if(additionalData.Data.referToJudge!= null) then true
@@ -80,7 +85,7 @@ else false</text>
       <output id="OutputClause_1o4gc2a" label="Process Categories Identifiers" name="processCategories" typeRef="string" />
       <rule id="DecisionRule_046gs9f">
         <inputEntry id="UnaryTests_1xolm0z">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0j3x4bw">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -103,6 +108,9 @@ else false</text>
         <inputEntry id="UnaryTests_0oecj2r">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1masw8n">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1wtwdv7">
           <text></text>
         </inputEntry>
@@ -124,7 +132,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_167rsam">
         <inputEntry id="UnaryTests_0b2bxqj">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0he81p8">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -147,6 +155,9 @@ else false</text>
         <inputEntry id="UnaryTests_0ynqp6p">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1f7w9zs">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0u4bte5">
           <text></text>
         </inputEntry>
@@ -168,7 +179,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_0rt9dst">
         <inputEntry id="UnaryTests_0fwhfrt">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_01y87ki">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -191,6 +202,9 @@ else false</text>
         <inputEntry id="UnaryTests_0gnvjbg">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1rh87gn">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0spvc5y">
           <text></text>
         </inputEntry>
@@ -212,7 +226,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_02cq4n1">
         <inputEntry id="UnaryTests_04f3dej">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0ycpwh3">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -235,6 +249,9 @@ else false</text>
         <inputEntry id="UnaryTests_0860y5x">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1878qrn">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1a4sy6m">
           <text></text>
         </inputEntry>
@@ -251,6 +268,382 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_17zwv52">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1w1cac2">
+        <inputEntry id="UnaryTests_1saj8s1">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15a7tgl">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0g27ptb">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0rj46o7">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jxc1k0">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kv1gj2">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13s9qkg">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1hy2360">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1akdjew">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01jnovl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06fxa3k">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1pl0sou">
+          <text>"JudgeDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0aj7agt">
+          <text>"Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0wcgs5y">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1k7byg3">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0ntwnuc">
+        <inputEntry id="UnaryTests_0qg96cv">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0689l05">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yvz5wq">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1xs90x1">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qny128">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1c5l2if">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_003kagf">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1x5vk3h">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0dw2ttt">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pgxf4e">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1628s86">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0h9x0se">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_04lpbwk">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0nvs4fq">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1yqrodj">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0wgu1pf">
+        <inputEntry id="UnaryTests_1iwjg2f">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0yobwjc">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18x8dth">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wq3o6y">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1xf0s0g">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05u8fml">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1xtv4zj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1y5pho5">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bojlzk">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qdscj2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1prus48">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_179itoz">
+          <text>"JudgeDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_10dpok8">
+          <text>"Application for multiple types"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0brdvo0">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_02xfvs5">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_033g5k9">
+        <inputEntry id="UnaryTests_0fvwodc">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mqqtqr">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ggtes4">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12i0z59">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1c0vt69">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fhss09">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1clxdx9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1oqy8d9">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12t1gp8">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19b2v7n">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vhcx3f">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1wp43zk">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_09vi5xd">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_109d7fu">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_04p83bd">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1mkmryy">
+        <inputEntry id="UnaryTests_05uhw5g">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ozm0ff">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17f3d3q">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zkfi5n">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18lg0ir">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0rwo5ar">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qj4u1h">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_018k73m">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0o78qbk">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_178mmn8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1itxkqj">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0rct2y3">
+          <text>"JudgeDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1whxmif">
+          <text> "Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_13d4sp5">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1qfnp6g">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0ih0ywu">
+        <inputEntry id="UnaryTests_044khxg">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0es9ncr">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ilihd9">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_026hqij">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03964d6">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0o99nsg">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01um4f4">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1o032c2">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17wicy5">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0n301in">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vxpn3j">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0dtx870">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0pd1edb">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0qcqyd6">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0a2gg4b">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1necgwe">
+        <inputEntry id="UnaryTests_06tvog6">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_199keqd">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0umejfc">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1a0jjpo">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_00434e9">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1q97jpt">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1tbyfyp">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01pqitl">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0e674eo">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15vieko">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18c7sxl">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_09ggf15">
+          <text>"JudgeDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0n6x723">
+          <text>"Application for multiple types"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ee2qlz">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1hze6vr">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1qjjm8h">
+        <inputEntry id="UnaryTests_0hs28yv">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1m0cvv0">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1krqldd">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kvwwac">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0sp1vg0">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09it83z">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1kk7yz2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1dnqvym">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ygtmq0">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hwdtqb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1h9cmq0">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1rn8u06">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_13o65ra">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_06im13l">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_08vzyta">
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
@@ -278,6 +671,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0b1mcb9">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01zzqbx">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0ww4l56">
           <text></text>
@@ -323,6 +719,9 @@ else false</text>
         <inputEntry id="UnaryTests_1axg4dz">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1ozqxq1">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1nrxaz8">
           <text></text>
         </inputEntry>
@@ -366,6 +765,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0xa66oj">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0mcnsgu">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_113nqz0">
           <text></text>
@@ -411,6 +813,9 @@ else false</text>
         <inputEntry id="UnaryTests_1nv3zb5">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_000csea">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0vev614">
           <text></text>
         </inputEntry>
@@ -454,6 +859,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0rfbpao">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ibbhy0">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0uwh4yo">
           <text></text>
@@ -499,6 +907,9 @@ else false</text>
         <inputEntry id="UnaryTests_1kw60fr">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0u2nmd3">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1vlivok">
           <text></text>
         </inputEntry>
@@ -542,6 +953,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_02qntb0">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0uidsrl">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1642wcy">
           <text></text>
@@ -587,6 +1001,9 @@ else false</text>
         <inputEntry id="UnaryTests_19b1bck">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_18at8r0">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_084whfm">
           <text></text>
         </inputEntry>
@@ -630,6 +1047,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ca09d2">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1imkero">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0jijl19">
           <text></text>
@@ -675,6 +1095,9 @@ else false</text>
         <inputEntry id="UnaryTests_02b2hh8">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1ov7p62">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0w095sa">
           <text></text>
         </inputEntry>
@@ -718,6 +1141,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1wozqed">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ngjbk8">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_08j1mb9">
           <text></text>
@@ -763,6 +1189,9 @@ else false</text>
         <inputEntry id="UnaryTests_11mdgyi">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0jono2a">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_14x9h9t">
           <text></text>
         </inputEntry>
@@ -784,7 +1213,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_0jncb6o">
         <inputEntry id="UnaryTests_0l5mxjf">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_059j2hq">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -807,6 +1236,9 @@ else false</text>
         <inputEntry id="UnaryTests_1n83kdv">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0ln658b">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1v096uc">
           <text></text>
         </inputEntry>
@@ -828,7 +1260,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_0h6xns3">
         <inputEntry id="UnaryTests_1x9zmtc">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0jmntdn">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -851,6 +1283,9 @@ else false</text>
         <inputEntry id="UnaryTests_1ob30il">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1vk8r5l">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_00i9b3q">
           <text></text>
         </inputEntry>
@@ -872,7 +1307,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_0fsu84p">
         <inputEntry id="UnaryTests_08wuxd5">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1vqghb0">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -895,6 +1330,9 @@ else false</text>
         <inputEntry id="UnaryTests_1jxo8qd">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1qe23bi">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_12lp4i1">
           <text></text>
         </inputEntry>
@@ -916,7 +1354,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_11w0wxf">
         <inputEntry id="UnaryTests_1mmwt6s">
-          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC","TRIGGER_LOCATION_UPDATE"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_023wybc">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -939,6 +1377,9 @@ else false</text>
         <inputEntry id="UnaryTests_0bhn0wf">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0vqfuvv">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1f2zpq2">
           <text></text>
         </inputEntry>
@@ -955,6 +1396,382 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1yuoynr">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0b5s8pt">
+        <inputEntry id="UnaryTests_1x8x8sz">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0cy3alr">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0n7dx33">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0v07b8x">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1y10oh2">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01ojtnp">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0azq6v4">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13virrv">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1a6tv19">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1dlg7ph">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_017pnz9">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1tylsrg">
+          <text>"JudgeDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0u96mf8">
+          <text>"Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0xta78m">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1pajltk">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0h1hdro">
+        <inputEntry id="UnaryTests_1h0bpvf">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0o8k13a">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18xllfv">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0q6br30">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mwv9d2">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0sb3gx1">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_051ih1d">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tzuhz8">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1099jn3">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16l9k8y">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1k9807h">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_052fz2w">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0c262ra">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1gwbsv8">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1jyqtq4">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0anmnel">
+        <inputEntry id="UnaryTests_0xb76y9">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0eictgy">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vzf9pc">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zxa54p">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wnag2z">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14gcq1u">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1o14shf">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0w09q3e">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vdiw89">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17dm4bh">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1kcqyll">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1ary9mw">
+          <text>"JudgeDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0xvrfd4">
+          <text>"Application for multiple types"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_178pojr">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0y8gdx5">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1idgxio">
+        <inputEntry id="UnaryTests_0xja5hw">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1rptf9t">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ilqpsq">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1iphjod">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0p4vvjw">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0j6zh3h">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11ttssi">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14axqaa">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19n8wa4">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0dxvy3x">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hox3s5">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0dpedoe">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0su8uan">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_13wh8t4">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_01dzd3z">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1m15oxx">
+        <inputEntry id="UnaryTests_01b9lcg">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0252ig8">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0p051jy">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_006pi2h">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kahryr">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0gqttu2">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12hepro">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1i6nv7n">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0r2neas">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_07ra2l0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ga3hmg">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_09w4yf2">
+          <text>"JudgeDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1t3p0jj">
+          <text> "Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1f11xvr">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0gys0ef">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0cxyvsz">
+        <inputEntry id="UnaryTests_1812gan">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_065zf6b">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09zct5e">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11pkx4d">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0gc2gno">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pjd3v4">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17nebjv">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ulz6lx">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tusy1n">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0b0wgbw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qb65ti">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0n3a59v">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0a5tall">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1u7wzqh">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ght8w6">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0gfvykz">
+        <inputEntry id="UnaryTests_1gc62pu">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09xuj1q">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1c6umrf">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12vbucs">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04dygej">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1c3lgby">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17c3qua">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jm4lup">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1gx42xi">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0iy8mml">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1urgczv">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0cxaotk">
+          <text>"JudgeDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ev5jbh">
+          <text>"Application for multiple types"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_003hocy">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1tkgl2a">
+          <text>"generalApplications"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_01hfrig">
+        <inputEntry id="UnaryTests_0rurqw9">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mr2cow">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12u9ma4">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1a4jaky">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1e7i9cz">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0yv35iy">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0z2501x">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qsdb36">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ybsvbp">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pd9qcz">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1c36rjy">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0mtruyy">
+          <text>"JudgeRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1cuyksx">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_01nt01q">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0je33e4">
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
@@ -982,6 +1799,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1mnixvx">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1i4sbt3">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_193dfzw">
           <text></text>
@@ -1027,6 +1847,9 @@ else false</text>
         <inputEntry id="UnaryTests_1nocxyu">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0ad3rev">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1vi13vr">
           <text></text>
         </inputEntry>
@@ -1070,6 +1893,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_098s97s">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15mp6xm">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0txt1on">
           <text></text>
@@ -1115,6 +1941,9 @@ else false</text>
         <inputEntry id="UnaryTests_0nlhqqq">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1i49u9v">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1n3l5rq">
           <text></text>
         </inputEntry>
@@ -1158,6 +1987,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0b9l26t">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19v83y0">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1bmclva">
           <text></text>
@@ -1203,6 +2035,9 @@ else false</text>
         <inputEntry id="UnaryTests_0eu4g7d">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1gvl3mm">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0oc7z1h">
           <text></text>
         </inputEntry>
@@ -1246,6 +2081,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_00ni92y">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ajua3f">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_09dn1rp">
           <text></text>
@@ -1291,6 +2129,9 @@ else false</text>
         <inputEntry id="UnaryTests_1i3vkpo">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0k9g3ez">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1a76uxh">
           <text></text>
         </inputEntry>
@@ -1334,6 +2175,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0ool9cq">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mb75jp">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0lex4u3">
           <text></text>
@@ -1379,6 +2223,9 @@ else false</text>
         <inputEntry id="UnaryTests_0on9sli">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_07p82xl">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0zrgc0z">
           <text></text>
         </inputEntry>
@@ -1422,6 +2269,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_07ryt8f">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ol3enm">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0qw3od0">
           <text></text>
@@ -1467,6 +2317,9 @@ else false</text>
         <inputEntry id="UnaryTests_06lvzet">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0thzum6">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_161bk9e">
           <text></text>
         </inputEntry>
@@ -1486,53 +2339,9 @@ else false</text>
           <text>"generalApplications"</text>
         </outputEntry>
       </rule>
-      <rule id="DecisionRule_1aoortf">
-        <inputEntry id="UnaryTests_03awqgl">
-          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1gaqlxp">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_018urlo">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1tklesg">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0vu8k2u">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0vaxdp5">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0zt27la">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1pzycwi">
-          <text>false</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1ux63ok">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_05awy2i">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_0ldczpl">
-          <text>"LegalAdvisorDecideOnApplication"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0n2v66n">
-          <text>"Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0vmb727">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0rfhopv">
-          <text>"generalApplicationsBeforeSdo"</text>
-        </outputEntry>
-      </rule>
       <rule id="DecisionRule_0n371xx">
         <inputEntry id="UnaryTests_15syb8q">
-          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0rbr0i9">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -1555,6 +2364,9 @@ else false</text>
         <inputEntry id="UnaryTests_11i3x3n">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0k72egq">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0ta4n2b">
           <text></text>
         </inputEntry>
@@ -1576,7 +2388,7 @@ else false</text>
       </rule>
       <rule id="DecisionRule_1502jbn">
         <inputEntry id="UnaryTests_05ixcd6">
-          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1m2y5ki">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -1599,6 +2411,9 @@ else false</text>
         <inputEntry id="UnaryTests_1yvjg00">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1ky1j2n">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_16v9cm2">
           <text></text>
         </inputEntry>
@@ -1618,9 +2433,56 @@ else false</text>
           <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_1aoortf">
+        <inputEntry id="UnaryTests_03awqgl">
+          <text>"END_BUSINESS_PROCESS_GASPEC"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1gaqlxp">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_018urlo">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1tklesg">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vu8k2u">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vaxdp5">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zt27la">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pzycwi">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tquy7z">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ux63ok">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05awy2i">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0ldczpl">
+          <text>"LegalAdvisorDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0n2v66n">
+          <text>"Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0vmb727">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0rfhopv">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_0zdezfb">
         <inputEntry id="UnaryTests_1m1qxfg">
-          <text>"END_BUSINESS_PROCESS_GASPEC","RESPOND_TO_APPLICATION"</text>
+          <text>"END_BUSINESS_PROCESS_GASPEC"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_11803rc">
           <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
@@ -1643,6 +2505,9 @@ else false</text>
         <inputEntry id="UnaryTests_0ju2tv3">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1blgbw9">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_18v3sz8">
           <text></text>
         </inputEntry>
@@ -1659,6 +2524,382 @@ else false</text>
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0quqdhw">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0vz6qq0">
+        <inputEntry id="UnaryTests_1ho86ro">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0acjcng">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ggoi40">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1feywep">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18d37fb">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1afnrvm">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0at49vj">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0l7byqv">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1933lrz">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yj5gm8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_106mll9">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_03b7546">
+          <text>"LegalAdvisorDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0p5q5q2">
+          <text>"Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_15ij7bk">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1bdmmav">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0c8i4x2">
+        <inputEntry id="UnaryTests_1vfk6e4">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1c1wv1q">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_086882w">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hk6468">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1beou89">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vkw0v7">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_07rfexx">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1gyv6s2">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0mypd8x">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0royraa">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13pf02y">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0vgtuov">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0v49pkm">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0w3hwkb">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1be1rn9">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0gy6ddg">
+        <inputEntry id="UnaryTests_1o6upq5">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hvi46k">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pd1kgu">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_198zfs2">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0gg05tf">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1oeukv4">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mtbkta">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1s9gm7t">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0t1akm0">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tiq95y">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_026ef3o">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0xjfrjn">
+          <text>"LegalAdvisorDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0sb5ovd">
+          <text>"Application for multiple types"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_00ufzxo">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1y7y8vc">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_15zujzm">
+        <inputEntry id="UnaryTests_1c68hdt">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1h9lh7g">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1latxz9">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ajy6oe">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0s1m949">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0k4em6q">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1sw3ny8">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ecy7wg">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_08bh58n">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17utau5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1s4sedl">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0fhjv7n">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0i1rsa8">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0u81wm0">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1uzm7ge">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1e5jskc">
+        <inputEntry id="UnaryTests_06du8cp">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jz6ruw">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0041o2u">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0jrs9qd">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0bhdim1">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0i63ow7">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16cv1h3">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0022j0b">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1x3sdhb">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xrzhd8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qdqmhf">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1j04kw4">
+          <text>"LegalAdvisorDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0z9xvzw">
+          <text> "Application for " + lower case(replace(additionalData.Data.generalAppType.types[1], "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0fyln91">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0qis766">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0diarj7">
+        <inputEntry id="UnaryTests_0wxxbyw">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1rq62s3">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1eocoqr">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1k0i3ya">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vmit0e">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hlsuwe">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0atpx49">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1w673ll">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xylg36">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1p01rcr">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0t6540x">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_020lly5">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1b67jgj">
+          <text>lower case(replace(additionalData.Data.generalAppType.types[1], "_"," ")) + " App"  + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_07cnl0e">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ihlp57">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1h3s56j">
+        <inputEntry id="UnaryTests_0dlm7px">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0o9jvdh">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_088iry9">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13w1a48">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qr6e1v">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04ojsjh">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1cwp3wo">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_02e0xcg">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13rjqwt">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pzujyb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qkyc33">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_189rqcf">
+          <text>"LegalAdvisorDecideOnApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0j54nbj">
+          <text>"Application for multiple types"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0b1sl6p">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1q74zxa">
+          <text>"generalApplicationsBeforeSdo"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_14pycrj">
+        <inputEntry id="UnaryTests_0rdba2h">
+          <text>"RESPOND_TO_APPLICATION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0sjhawf">
+          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1xbfwnj">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1cu0bjm">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_107guos">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0oeoo4h">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_00jk0k9">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jy1kob">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1oxcxze">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qh74af">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0k36gnu">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1tq3c1f">
+          <text>"LegalAdvisorRevisitApplication"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1xmwp4d">
+          <text>"Application for multiple types" + " - revisited " + lower case(replace(additionalData.Data.judicialDecision.decision, "_"," "))</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0t6n6a5">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1uwg83n">
           <text>"generalApplicationsBeforeSdo"</text>
         </outputEntry>
       </rule>
@@ -1686,6 +2927,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0syvzhl">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0cgysd0">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ti3033">
           <text></text>
@@ -1731,6 +2975,9 @@ else false</text>
         <inputEntry id="UnaryTests_0r0pl1q">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1k0mw0o">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_04vu6po">
           <text></text>
         </inputEntry>
@@ -1774,6 +3021,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0jxjecy">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06qmhk0">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0w0hgdm">
           <text></text>
@@ -1819,6 +3069,9 @@ else false</text>
         <inputEntry id="UnaryTests_1d7iegw">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1143lxd">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_10hrp0l">
           <text></text>
         </inputEntry>
@@ -1862,6 +3115,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0nwnvhj">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0589e4l">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_165uwx9">
           <text></text>
@@ -1907,6 +3163,9 @@ else false</text>
         <inputEntry id="UnaryTests_09drgg4">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0jdy04x">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0f7b5a4">
           <text></text>
         </inputEntry>
@@ -1950,6 +3209,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_090vkn1">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0x7beyx">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1wj5umc">
           <text></text>
@@ -1995,6 +3257,9 @@ else false</text>
         <inputEntry id="UnaryTests_1q938s7">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1d3efrp">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_18wiqty">
           <text></text>
         </inputEntry>
@@ -2038,6 +3303,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1k32t4w">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pwdrfr">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0zsjyed">
           <text></text>
@@ -2083,6 +3351,9 @@ else false</text>
         <inputEntry id="UnaryTests_1gh2plu">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_075z7lb">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0528mnx">
           <text></text>
         </inputEntry>
@@ -2126,6 +3397,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1k9e9x2">
           <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tq0v4p">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1alwf4v">
           <text></text>
@@ -2171,6 +3445,9 @@ else false</text>
         <inputEntry id="UnaryTests_0sm1dn8">
           <text>false</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1xj303e">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1mej8t8">
           <text></text>
         </inputEntry>
@@ -2214,6 +3491,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_10nhxqs">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13lf63i">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0o57zfw">
           <text></text>
@@ -2259,6 +3539,9 @@ else false</text>
         <inputEntry id="UnaryTests_1ur1rh5">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_17lor3c">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_06dzeuj">
           <text></text>
         </inputEntry>
@@ -2302,6 +3585,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0oro08q">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qkyki9">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0bx2c5r">
           <text></text>
@@ -2347,6 +3633,9 @@ else false</text>
         <inputEntry id="UnaryTests_0gkzm4q">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1ydh4fj">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0ope7wa">
           <text></text>
         </inputEntry>
@@ -2390,6 +3679,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_021xvdp">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1tfkcxm">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_11944md">
           <text></text>
@@ -2435,6 +3727,9 @@ else false</text>
         <inputEntry id="UnaryTests_1dpfvej">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0i30cwy">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0919haa">
           <text></text>
         </inputEntry>
@@ -2478,6 +3773,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0plwt4o">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1g2jlut">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1qfh7tr">
           <text></text>
@@ -2523,6 +3821,9 @@ else false</text>
         <inputEntry id="UnaryTests_1bv1bmj">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1swkmu5">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1crlhit">
           <text></text>
         </inputEntry>
@@ -2566,6 +3867,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1s9ys7j">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ncd2jg">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_147ktb0">
           <text></text>
@@ -2611,6 +3915,9 @@ else false</text>
         <inputEntry id="UnaryTests_0pbf8iy">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_06a0nnm">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1qtkpf1">
           <text></text>
         </inputEntry>
@@ -2654,6 +3961,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0ok14tu">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18pneqn">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_04ikap8">
           <text></text>
@@ -2699,6 +4009,9 @@ else false</text>
         <inputEntry id="UnaryTests_1f5lrsk">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_07dx23h">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1jh5tkn">
           <text></text>
         </inputEntry>
@@ -2742,6 +4055,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_15rg2rj">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1q3z849">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1rm4olm">
           <text></text>
@@ -2787,6 +4103,9 @@ else false</text>
         <inputEntry id="UnaryTests_0qu3ew4">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_199utg9">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_18nofkx">
           <text></text>
         </inputEntry>
@@ -2830,6 +4149,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0lkby76">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vf5ldo">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_05u0u0k">
           <text></text>
@@ -2875,6 +4197,9 @@ else false</text>
         <inputEntry id="UnaryTests_1tw5cms">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1kzcjbf">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_02j2kxe">
           <text></text>
         </inputEntry>
@@ -2918,6 +4243,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0hl4vh6">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fe1iog">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0s36l3a">
           <text>true</text>
@@ -2963,6 +4291,9 @@ else false</text>
         <inputEntry id="UnaryTests_0dh6rq2">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_03hktlh">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0k7qcbu">
           <text>true</text>
         </inputEntry>
@@ -3006,6 +4337,9 @@ else false</text>
         </inputEntry>
         <inputEntry id="UnaryTests_19o7vb8">
           <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0r9cfx7">
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1sw0h6f">
           <text>false</text>
@@ -3051,6 +4385,9 @@ else false</text>
         <inputEntry id="UnaryTests_1qerixt">
           <text>true</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1egso69">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1bgzh1a">
           <text>false</text>
         </inputEntry>
@@ -3093,6 +4430,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1mw376f">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tr9nfk">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0zpym82">
@@ -3139,6 +4479,9 @@ else false</text>
         <inputEntry id="UnaryTests_00mjp2t">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1kps289">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_14aqlwq">
           <text></text>
         </inputEntry>
@@ -3181,6 +4524,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_13tb2iv">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pct0nv">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_12gi93k">
@@ -3227,6 +4573,9 @@ else false</text>
         <inputEntry id="UnaryTests_0j24wpm">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1xfb50r">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1h5t43b">
           <text></text>
         </inputEntry>
@@ -3269,6 +4618,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1qqsirc">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zcmwzd">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0z3zisk">
@@ -3315,6 +4667,9 @@ else false</text>
         <inputEntry id="UnaryTests_1japzxm">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0axcrkb">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1wpsfdc">
           <text></text>
         </inputEntry>
@@ -3357,6 +4712,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0hzsq1i">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jqssar">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_03azrte">
@@ -3403,6 +4761,9 @@ else false</text>
         <inputEntry id="UnaryTests_1dzx7ph">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_00j8jvy">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1wtezix">
           <text></text>
         </inputEntry>
@@ -3445,6 +4806,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ii8lzs">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10owo4x">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_10223wl">
@@ -3491,6 +4855,9 @@ else false</text>
         <inputEntry id="UnaryTests_086yycn">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0ys5rdq">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1vuhmt9">
           <text></text>
         </inputEntry>
@@ -3533,6 +4900,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0zwlkzn">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0nvnge3">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1akl7uc">
@@ -3579,6 +4949,9 @@ else false</text>
         <inputEntry id="UnaryTests_1c0evmr">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1grub1g">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_05pg0nl">
           <text></text>
         </inputEntry>
@@ -3621,6 +4994,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0gdzf2a">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_08o0tuu">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1iklz03">
@@ -3667,6 +5043,9 @@ else false</text>
         <inputEntry id="UnaryTests_1p5fl06">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_13vtbzo">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1dthdza">
           <text></text>
         </inputEntry>
@@ -3711,6 +5090,9 @@ else false</text>
         <inputEntry id="UnaryTests_1l7veu4">
           <text>-</text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0io3bno">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0avxtni">
           <text></text>
         </inputEntry>
@@ -3753,6 +5135,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0jv449h">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0khbncq">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0rpwzgr">
@@ -3799,6 +5184,9 @@ else false</text>
         <inputEntry id="UnaryTests_02m6vo1">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1plvwsp">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1jq8fta">
           <text></text>
         </inputEntry>
@@ -3841,6 +5229,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_063svbt">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0a3vy6j">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1fsbtio">
@@ -3887,6 +5278,9 @@ else false</text>
         <inputEntry id="UnaryTests_0m1meou">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0u2kysd">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_02f9v27">
           <text></text>
         </inputEntry>
@@ -3929,6 +5323,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ai2d2d">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uk7srl">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1vyzqz0">
@@ -3975,6 +5372,9 @@ else false</text>
         <inputEntry id="UnaryTests_1cvbrze">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1c16vjl">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1m7339v">
           <text></text>
         </inputEntry>
@@ -4017,6 +5417,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ahyxn9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1f4nf4r">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_17mujco">
@@ -4063,6 +5466,9 @@ else false</text>
         <inputEntry id="UnaryTests_0igf5h7">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_1nii5tj">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1ar78ai">
           <text></text>
         </inputEntry>
@@ -4105,6 +5511,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0jtpsxa">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0cywaa9">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0t1vxqe">
@@ -4151,6 +5560,9 @@ else false</text>
         <inputEntry id="UnaryTests_0b4m0ua">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_07dmhju">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_08ko5eb">
           <text></text>
         </inputEntry>
@@ -4193,6 +5605,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1h0yz3c">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wvuod0">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_16b4vfh">
@@ -4239,6 +5654,9 @@ else false</text>
         <inputEntry id="UnaryTests_0dpqy55">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0k9yv7t">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0x71sse">
           <text></text>
         </inputEntry>
@@ -4281,6 +5699,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0vxvk6s">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0gza5ce">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ynots6">
@@ -4327,6 +5748,9 @@ else false</text>
         <inputEntry id="UnaryTests_1h1jqt7">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0tip24v">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_06ukd0b">
           <text></text>
         </inputEntry>
@@ -4369,6 +5793,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0dwtrqe">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1brco4w">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0ay909n">
@@ -4417,6 +5844,9 @@ else false</text>
         <inputEntry id="UnaryTests_1gijj60">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_0nq5onz">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_0cqds7h">
           <text></text>
         </inputEntry>
@@ -4463,6 +5893,9 @@ else false</text>
         <inputEntry id="UnaryTests_0e4unxx">
           <text></text>
         </inputEntry>
+        <inputEntry id="UnaryTests_16td43v">
+          <text></text>
+        </inputEntry>
         <inputEntry id="UnaryTests_1bmbh5w">
           <text></text>
         </inputEntry>
@@ -4505,6 +5938,9 @@ else false</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_067j89w">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19te4ew">
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1398lbx">

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmnga/CamundaGaSubmissionTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmnga/CamundaGaSubmissionTaskWaInitiationTest.java
@@ -60,6 +60,314 @@ public class CamundaGaSubmissionTaskWaInitiationTest extends DmnDecisionTableBas
 
     @ParameterizedTest
     @CsvSource(value = {
+        "END_BUSINESS_PROCESS_GASPEC", "RESPOND_TO_APPLICATION"
+    })
+    void when_urgent_ga_with_consent_order_uncloaked_referToJudge_judgeRevisit_with_case_local_court(String eventId) {
+
+        /*if(caseData.generalAppUrgencyRequirement.generalAppUrgency != "Yes") then 2 else 10*/
+        Map<String, Object> data = new HashMap<>();
+        data.put("generalAppUrgencyRequirement", Map.of(
+            "generalAppUrgency", true
+        ));
+        data.put("isCcmccLocation", false);
+        data.put("generalAppConsentOrder", true);
+        data.put("generalAppType", Map.of(
+            "types", asList("SUMMARY_JUDGEMENT")
+        ));
+        data.put("referToJudge", Map.of(
+            "judgeReferAdditionalInfo", "judge refer"
+        ));
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+        data.put("judicialDecision", Map.of(
+            "decision", "REQUEST_MORE_INFO"
+        ));
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", eventId);
+        inputVariables.putValue("postEventState", "APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList
+                       .get(0).get("name"),
+                   is("summary judgement App - revisited request more info"));
+        assertThat(workTypeResultList.get(0).get("taskId"), is("JudgeRevisitApplication"));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "END_BUSINESS_PROCESS_GASPEC", "RESPOND_TO_APPLICATION"
+    })
+    void when_urgent_ga_with_consent_order_uncloaked_ReferToJudge_judgeRevisit_with_ccmcc_location(String eventId) {
+
+        /*if(caseData.generalAppUrgencyRequirement.generalAppUrgency != "Yes") then 2 else 10*/
+        Map<String, Object> data = new HashMap<>();
+        data.put("generalAppUrgencyRequirement", Map.of(
+            "generalAppUrgency", true
+        ));
+        data.put("isCcmccLocation", true);
+        data.put("generalAppConsentOrder", true);
+        data.put("generalAppType", Map.of(
+            "types", asList("SUMMARY_JUDGEMENT")
+        ));
+        data.put("referToJudge", Map.of(
+            "judgeReferAdditionalInfo", "judge refer"
+        ));
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+        data.put("judicialDecision", Map.of(
+            "decision", "REQUEST_MORE_INFO"
+        ));
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", eventId);
+        inputVariables.putValue("postEventState", "APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList
+                       .get(0).get("name"),
+                   is("summary judgement App - revisited request more info"));
+        assertThat(workTypeResultList.get(0).get("taskId"), is("JudgeRevisitApplication"));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "END_BUSINESS_PROCESS_GASPEC", "RESPOND_TO_APPLICATION"
+    })
+    void when_urgent_ga_with_consent_order_uncloaked_judgeRevisit_after_additionalPaymentMade(String eventId) {
+
+        /*if(caseData.generalAppUrgencyRequirement.generalAppUrgency != "Yes") then 2 else 10*/
+        Map<String, Object> data = new HashMap<>();
+        data.put("generalAppUrgencyRequirement", Map.of(
+            "generalAppUrgency", true
+        ));
+        data.put("isCcmccLocation", true);
+        data.put("generalAppConsentOrder", true);
+        data.put("generalAppType", Map.of(
+            "types", asList("STRIKE_OUT")
+        ));
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+        data.put("judicialDecision", Map.of(
+            "decision", "REQUEST_MORE_INFO"
+        ));
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", eventId);
+        inputVariables.putValue("postEventState", "APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList
+                       .get(0).get("name"),
+                   is("strike out App - revisited request more info"));
+        assertThat(workTypeResultList.get(0).get("taskId"), is("JudgeRevisitApplication"));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"
+    })
+    void when_non_urgent_ga_with_consent_order_uncloaked_judgeRevisit_after_additionalPaymentMade(String eventId) {
+
+        /*if(caseData.generalAppUrgencyRequirement.generalAppUrgency != "Yes") then 2 else 10*/
+        Map<String, Object> data = new HashMap<>();
+        data.put("generalAppUrgencyRequirement", Map.of(
+            "generalAppUrgency", false
+        ));
+        data.put("isCcmccLocation", true);
+        data.put("generalAppConsentOrder", true);
+        data.put("generalAppType", Map.of(
+            "types", asList("STRIKE_OUT")
+        ));
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+        data.put("judicialDecision", Map.of(
+            "decision", "REQUEST_MORE_INFO"
+        ));
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", eventId);
+        inputVariables.putValue("postEventState", "APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList
+                       .get(0).get("name"),
+                   is("strike out App - revisited request more info"));
+        assertThat(workTypeResultList.get(0).get("taskId"), is("JudgeRevisitApplication"));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "END_BUSINESS_PROCESS_GASPEC", "RESPOND_TO_APPLICATION"
+    })
+    void when_urgent_ga_consent_order_uncloaked_ReferLegalAdvisor_LegalAdvisorRevisit_with_local_court(String eventId) {
+
+        /*if(caseData.generalAppUrgencyRequirement.generalAppUrgency != "Yes") then 2 else 10*/
+        Map<String, Object> data = new HashMap<>();
+        data.put("generalAppUrgencyRequirement", Map.of(
+            "generalAppUrgency", true
+        ));
+        data.put("isCcmccLocation", false);
+        data.put("generalAppConsentOrder", true);
+        data.put("generalAppType", Map.of(
+            "types", asList("SUMMARY_JUDGEMENT")
+        ));
+        data.put("referToLegalAdvisor", Map.of(
+            "judgeReferAdditionalInfo", "judge refer"
+        ));
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+        data.put("judicialDecision", Map.of(
+            "decision", "REQUEST_MORE_INFO"
+        ));
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", eventId);
+        inputVariables.putValue("postEventState", "APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList
+                       .get(0).get("name"),
+                   is("summary judgement App - revisited request more info"));
+        assertThat(workTypeResultList.get(0).get("taskId"), is("LegalAdvisorRevisitApplication"));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "END_BUSINESS_PROCESS_GASPEC", "RESPOND_TO_APPLICATION"
+    })
+    void when_urgent_ga_with_consent_order_uncloaked_ReferToLegalAdvisor_LaRevisit_with_ccmcc_location(String eventId) {
+
+        /*if(caseData.generalAppUrgencyRequirement.generalAppUrgency != "Yes") then 2 else 10*/
+        Map<String, Object> data = new HashMap<>();
+        data.put("generalAppUrgencyRequirement", Map.of(
+            "generalAppUrgency", true
+        ));
+        data.put("isCcmccLocation", true);
+        data.put("generalAppConsentOrder", true);
+        data.put("generalAppType", Map.of(
+            "types", asList("SUMMARY_JUDGEMENT")
+        ));
+        data.put("referToLegalAdvisor", Map.of(
+            "judgeReferAdditionalInfo", "judge refer"
+        ));
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+        data.put("judicialDecision", Map.of(
+            "decision", "REQUEST_MORE_INFO"
+        ));
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", eventId);
+        inputVariables.putValue("postEventState", "APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList
+                       .get(0).get("name"),
+                   is("summary judgement App - revisited request more info"));
+        assertThat(workTypeResultList.get(0).get("taskId"), is("LegalAdvisorRevisitApplication"));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "END_BUSINESS_PROCESS_GASPEC", "RESPOND_TO_APPLICATION"
+    })
+    void when_urgent_ga_with_consent_order_uncloaked_LegalAdvisorRevisit_after_additionalPaymentMade(String eventId) {
+
+        /*if(caseData.generalAppUrgencyRequirement.generalAppUrgency != "Yes") then 2 else 10*/
+        Map<String, Object> data = new HashMap<>();
+        data.put("generalAppUrgencyRequirement", Map.of(
+            "generalAppUrgency", true
+        ));
+        data.put("isCcmccLocation", true);
+        data.put("generalAppConsentOrder", true);
+        data.put("generalAppType", Map.of(
+            "types", asList("EXTEND_TIME")
+        ));
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+        data.put("judicialDecision", Map.of(
+            "decision", "REQUEST_MORE_INFO"
+        ));
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", eventId);
+        inputVariables.putValue("postEventState", "APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList
+                       .get(0).get("name"),
+                   is("extend time App - revisited request more info"));
+        assertThat(workTypeResultList.get(0).get("taskId"), is("LegalAdvisorRevisitApplication"));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"
+    })
+    void when_non_urgent_ga_with_consent_order_uncloaked_JudgeRevisit_after_additionalPaymentMade(String eventId) {
+
+        /*if(caseData.generalAppUrgencyRequirement.generalAppUrgency != "Yes") then 2 else 10*/
+        Map<String, Object> data = new HashMap<>();
+        data.put("generalAppUrgencyRequirement", Map.of(
+            "generalAppUrgency", false
+        ));
+        data.put("isCcmccLocation", false);
+        data.put("generalAppConsentOrder", true);
+        data.put("generalAppType", Map.of(
+            "types", asList("EXTEND_TIME")
+        ));
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+        data.put("judicialDecision", Map.of(
+            "decision", "REQUEST_MORE_INFO"
+        ));
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", eventId);
+        inputVariables.putValue("postEventState", "APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList
+                       .get(0).get("name"),
+                   is("extend time App - revisited request more info"));
+        assertThat(workTypeResultList.get(0).get("taskId"), is("JudgeRevisitApplication"));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
         "END_BUSINESS_PROCESS_GASPEC", "TRIGGER_LOCATION_UPDATE","RESPOND_TO_APPLICATION",
         "CHANGE_STATE_TO_AWAITING_JUDICIAL_DECISION"
     })


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-9618


### Change description ###

- Added new columns "isDecisionMadeOnConsentOrder", "isAlreadyReferedToJudge" , "isAlreadyReferedToLegalAdvisor".
- Cloumns "isAlreadyReferedToJudge", "isAlreadyReferedToLegalAdvisor" are used for reassigning the consent order to judge or leglar advisor which were already reafer by case worker.
- "isDecisionMadeOnConsentOrder" is used for reassigning the consent order to judge or legal advisor based on Refer to judge or Refer to legal advisor column.
- "isConsentOrderTypeReferToCaseWorker" updated name of column.
- Logic is also updated for reassigning the urgent consent orders.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
