### PR TITLE
CIV-9754 - Added WA task configuration for manage party details

### DIFF
--- a/charts/civil-task-configuration/values.aat.template.yaml
+++ b/charts/civil-task-configuration/values.aat.template.yaml
@@ -5,7 +5,7 @@ java:
   ingressHost: ${SERVICE_FQDN}
   environment:
       IDAM_CLIENT_ID: civil-service
-      IDAM_CLIENT_REDIRECT_URI: https://civil-ccd-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/oauth2/callback
+      IDAM_CLIENT_REDIRECT_URI: https://civil-camunda-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/oauth2/callback
       IDAM_API_URL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net
       IDAM_WEB_URL: https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net
       IDAM_S2S_AUTH_URL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal

--- a/src/main/resources/wa-task-cancellation-civil-civil.dmn
+++ b/src/main/resources/wa-task-cancellation-civil-civil.dmn
@@ -115,6 +115,52 @@
           <text></text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_13gnpyc">
+        <inputEntry id="UnaryTests_0ffw7y4">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hpxcmc">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0uy2wlf">
+          <text>"PROCEEDS_IN_HERITAGE_SYSTEM"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0iszhdl">
+          <text>"Cancel"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_193k259">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0rt4jh3">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_01zn9nc">
+          <text>"routineWork"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1ypo4v2">
+        <inputEntry id="UnaryTests_06p30oj">
+          <text>"CASE_DISMISSED"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0i9186w">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qgug0y">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0mic8j7">
+          <text>"Cancel"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0x5yet5">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0f6x15t">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0d5sa1l">
+          <text>"routineWork"</text>
+        </outputEntry>
+      </rule>
     </decisionTable>
   </decision>
   <dmndi:DMNDI>

--- a/src/main/resources/wa-task-cancellation-civil-civil.dmn
+++ b/src/main/resources/wa-task-cancellation-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-cancellation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.1.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-cancellation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
   <decision id="wa-task-cancellation-civil-civil" name="Civil Task cancellation DMN">
     <decisionTable id="DecisionTable_0z3jx1ga" hitPolicy="COLLECT">
       <input id="Input_1" label="From State">
@@ -135,7 +135,7 @@
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_01zn9nc">
-          <text>"updateContactInformation"</text>
+          <text>"routineWork"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1ypo4v2">
@@ -158,7 +158,7 @@
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0d5sa1l">
-          <text>"updateContactInformation"</text>
+          <text>"routineWork"</text>
         </outputEntry>
       </rule>
     </decisionTable>

--- a/src/main/resources/wa-task-cancellation-civil-civil.dmn
+++ b/src/main/resources/wa-task-cancellation-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-cancellation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-cancellation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.1.0">
   <decision id="wa-task-cancellation-civil-civil" name="Civil Task cancellation DMN">
     <decisionTable id="DecisionTable_0z3jx1ga" hitPolicy="COLLECT">
       <input id="Input_1" label="From State">
@@ -135,7 +135,7 @@
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_01zn9nc">
-          <text>"routineWork"</text>
+          <text>"updateContactInformation"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1ypo4v2">
@@ -158,7 +158,7 @@
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0d5sa1l">
-          <text>"routineWork"</text>
+          <text>"updateContactInformation"</text>
         </outputEntry>
       </rule>
     </decisionTable>

--- a/src/main/resources/wa-task-configuration-civil-civil.dmn
+++ b/src/main/resources/wa-task-configuration-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.4.1">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-configuration-civil-civil" name="Civil Task configuration DMN">
     <decisionTable id="DecisionTable_14cx0791" hitPolicy="COLLECT">
       <input id="InputClause_1gxyo7fa" label="CCD Case Data" camunda:inputVariable="caseData">
@@ -198,7 +198,7 @@ else "1"</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_00px7ye">
-          <text>"transferCaseOffline","transferCaseOfflineNotSuitableSDO" </text>
+          <text>"transferCaseOffline","transferCaseOfflineNotSuitableSDO","UpdateDetailsInCasemanSystem" </text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1koffim">
           <text>"roleCategory"</text>
@@ -699,6 +699,23 @@ else ""</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0h8co2o">
           <text>false</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0fwrdlc">
+        <inputEntry id="UnaryTests_1lrfg95">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bk18uh">
+          <text>"UpdateDetailsInCasemanSystem"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0xpehdn">
+          <text>"workType"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0b7qgd0">
+          <text>"routine_work"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0djj1yw">
+          <text>true</text>
         </outputEntry>
       </rule>
     </decisionTable>

--- a/src/main/resources/wa-task-initiation-civil-civil.dmn
+++ b/src/main/resources/wa-task-initiation-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.5.1">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-initiation-civil-civil" name="Civil Task initiation DMN">
     <decisionTable id="DecisionTable_0jtevuc" hitPolicy="COLLECT" biodi:annotationsWidth="400">
       <input id="Input_1" label="Event Id" biodi:width="319" camunda:inputVariable="eventId">
@@ -4255,6 +4255,65 @@ else
         </outputEntry>
         <outputEntry id="LiteralExpression_1w1nrva">
           <text>"standardDirectionsOrder"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1pao8c8">
+        <inputEntry id="UnaryTests_11mc249">
+          <text>"CONTACT_INFORMATION_UPDATED_WA"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15llwlt">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12v5ttc">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1aqg050">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_175pc0s">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1r33fft">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17unses">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pieigq">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0gz7fro">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0mcvoxi">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ee1z62">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lr803q">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0de9ns3">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vaoaud">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_039yisu">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_01dmccf">
+          <text>"UpdateDetailsInCasemanSystem"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1v3y56e">
+          <text>"Update details in Caseman"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ory3jt">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_06cn152">
+          <text>"routineWork"</text>
         </outputEntry>
       </rule>
     </decisionTable>

--- a/src/main/resources/wa-task-permissions-civil-civil.dmn
+++ b/src/main/resources/wa-task-permissions-civil-civil.dmn
@@ -117,7 +117,7 @@ else
       <rule id="DecisionRule_1mppa3l">
         <description>Listing Officer task permissions</description>
         <inputEntry id="UnaryTests_05z57xg">
-          <text>"transferCaseOffline","transferCaseOfflineNotSuitableSDO"</text>
+          <text>"transferCaseOffline","transferCaseOfflineNotSuitableSDO","UpdateDetailsInCasemanSystem"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0qmd6we">
           <text></text>
@@ -147,7 +147,7 @@ else
       <rule id="DecisionRule_0camg6y">
         <description>Access request for Listing Officers</description>
         <inputEntry id="UnaryTests_0acv1oh">
-          <text>"reviewSpecificAccessRequestAdmin"</text>
+          <text>"reviewSpecificAccessRequestAdmin","UpdateDetailsInCasemanSystem"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0jhhouw">
           <text></text>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaCancellationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaCancellationTest.java
@@ -26,7 +26,11 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
     }
 
     @ParameterizedTest
-    @MethodSource({"scenarioProvider"})
+    @MethodSource({
+        "scenarioTakesCaseOfflineEventProceedsInHeritageSystem",
+        "scenarioTakesCaseOfflineEventProceedsInHeritageSystem_ForUpdateContactInformation",
+        "scenarioTakesCaseOfflineEventCaseDismissedSystem"
+    })
     void given_multiple_event_ids_should_evaluate_dmn(String fromState,
                                                       String eventId,
                                                       String state,
@@ -41,7 +45,7 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
         assertThat(dmnDecisionTableResult.getResultList(), is(expectedDmnOutcome));
     }
 
-    public static Stream<Arguments> scenarioProvider() {
+    public static Stream<Arguments> scenarioTakesCaseOfflineEventProceedsInHeritageSystem() {
         List<Map<String, String>> outcome = List.of(
             Map.of(
                 "action", "Cancel",
@@ -60,30 +64,47 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
             Arguments.of(
                 "PROCEEDS_IN_HERITAGE_SYSTEM", "TAKE_CASE_OFFLINE", "",
                 outcome
-            )
-        );
-    }
-
-    public static Stream<Arguments> scenarioProviderSdo() {
-        List<Map<String, String>> outcome = List.of(
-            Map.of(
-                "action", "Cancel",
-                "processCategories", "standardDirectionsOrder"
-            )
-        );
-        return Stream.of(
-            Arguments.of(
-                "PROCEEDS_IN_HERITAGE_SYSTEM", "TAKE_CASE_OFFLINE", "any state",
-                outcome
-            ),
-            Arguments.of(
-                "PROCEEDS_IN_HERITAGE_SYSTEM", "TAKE_CASE_OFFLINE", "",
-                outcome
             ),
             Arguments.of(
                 "PROCEEDS_IN_HERITAGE_SYSTEM", "TAKE_CASE_OFFLINE", null,
                 outcome
 
+            )
+        );
+    }
+
+    public static Stream<Arguments> scenarioTakesCaseOfflineEventProceedsInHeritageSystem_ForUpdateContactInformation() {
+        List<Map<String, String>> outcome = List.of(
+            Map.of(
+                "action", "Cancel",
+                "processCategories", "updateContactInformation"
+            )
+        );
+        return Stream.of(
+            Arguments.of(
+                "any state", "TAKE_CASE_OFFLINE", "PROCEEDS_IN_HERITAGE_SYSTEM",
+                outcome
+            ),
+            Arguments.of(
+                "any state", "any state", "PROCEEDS_IN_HERITAGE_SYSTEM",
+                outcome
+            )
+        );
+    }
+
+    public static Stream<Arguments> scenarioTakesCaseOfflineEventCaseDismissedSystem() {
+        List<Map<String, String>> outcome = List.of(
+            Map.of(
+                "action", "Cancel",
+                "processCategories", "updateContactInformation"
+            )
+        );
+        return Stream.of(
+            Arguments.of(
+                "CASE_DISMISSED",
+                null,
+                null,
+                outcome
             )
         );
     }

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaCancellationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaCancellationTest.java
@@ -77,7 +77,7 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
         List<Map<String, String>> outcome = List.of(
             Map.of(
                 "action", "Cancel",
-                "processCategories", "updateContactInformation"
+                "processCategories", "routineWork"
             )
         );
         return Stream.of(
@@ -96,7 +96,7 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
         List<Map<String, String>> outcome = List.of(
             Map.of(
                 "action", "Cancel",
-                "processCategories", "updateContactInformation"
+                "processCategories", "routineWork"
             )
         );
         return Stream.of(

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaCancellationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaCancellationTest.java
@@ -60,11 +60,6 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
             Arguments.of(
                 "PROCEEDS_IN_HERITAGE_SYSTEM", "TAKE_CASE_OFFLINE", "",
                 outcome
-            ),
-            Arguments.of(
-                "PROCEEDS_IN_HERITAGE_SYSTEM", "TAKE_CASE_OFFLINE", null,
-                outcome
-
             )
         );
     }
@@ -93,14 +88,12 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
         );
     }
 
-
-
     @Test
     void if_this_test_fails_needs_updating_with_your_changes() {
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
         assertThat(logic.getInputs().size(), is(3));
         assertThat(logic.getOutputs().size(), is(4));
-        assertThat(logic.getRules().size(), is(4));
+        assertThat(logic.getRules().size(), is(6));
     }
 }

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaCancellationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaCancellationTest.java
@@ -73,7 +73,8 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
         );
     }
 
-    public static Stream<Arguments> scenarioTakesCaseOfflineEventProceedsInHeritageSystem_ForUpdateContactInformation() {
+    public static Stream<Arguments> scenarioTakesCaseOfflineEventProceedsInHeritageSystem_ForUpdateContactInformation()
+    {
         List<Map<String, String>> outcome = List.of(
             Map.of(
                 "action", "Cancel",

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaCancellationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaCancellationTest.java
@@ -28,7 +28,7 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
     @ParameterizedTest
     @MethodSource({
         "scenarioTakesCaseOfflineEventProceedsInHeritageSystem",
-        "scenarioTakesCaseOfflineEventProceedsInHeritageSystem_ForUpdateContactInformation",
+        "scenarioTakesCaseOfflineEventProceedsInHeritageSystem_ForUpdateContactInfo",
         "scenarioTakesCaseOfflineEventCaseDismissedSystem"
     })
     void given_multiple_event_ids_should_evaluate_dmn(String fromState,
@@ -73,8 +73,7 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
         );
     }
 
-    public static Stream<Arguments> scenarioTakesCaseOfflineEventProceedsInHeritageSystem_ForUpdateContactInformation()
-    {
+    public static Stream<Arguments> scenarioTakesCaseOfflineEventProceedsInHeritageSystem_ForUpdateContactInfo() {
         List<Map<String, String>> outcome = List.of(
             Map.of(
                 "action", "Cancel",

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
@@ -488,6 +488,76 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
         )));
     }
 
+    @Test
+    void when_taskId_then_return_routine_work_UpdateDetailsInCasemanSystem() {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("applicant1", Map.of(
+            "partyName", "Firstname LastName"
+
+        ));
+        caseData.put("applicant2", Map.of(
+            "partyName", "Firstname LastName"
+
+        ));
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("caseData", caseData);
+
+        inputVariables.putValue("taskAttributes", Map.of(
+            "taskType",
+            "UpdateDetailsInCasemanSystem"
+        ));
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList().stream()
+            .filter((r) -> r.containsValue("workType"))
+            .collect(Collectors.toList());
+
+        System.out.println(workTypeResultList);
+        assertThat(workTypeResultList.size(), is(1));
+
+        assertTrue(workTypeResultList.contains(Map.of(
+            "name", "workType",
+            "value", "routine_work",
+            "canReconfigure", "true"
+        )));
+    }
+
+    @Test
+    void when_taskId_then_return_roleCategory_UpdateDetailsInCasemanSystem() {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("applicant1", Map.of(
+            "partyName", "Firstname LastName"
+
+        ));
+        caseData.put("applicant2", Map.of(
+            "partyName", "Firstname LastName"
+
+        ));
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("caseData", caseData);
+
+        inputVariables.putValue("taskAttributes", Map.of(
+            "taskType",
+            "UpdateDetailsInCasemanSystem"
+        ));
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList().stream()
+            .filter((r) -> r.containsValue("roleCategory"))
+            .collect(Collectors.toList());
+
+        System.out.println(workTypeResultList);
+        assertThat(workTypeResultList.size(), is(1));
+
+        assertTrue(workTypeResultList.contains(Map.of(
+            "name", "roleCategory",
+            "value", "ADMIN",
+            "canReconfigure", "true"
+        )));
+    }
+
     @Value
     @Builder
     private static class Scenario {

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
@@ -37,7 +37,7 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
 
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(39));
+        assertThat(logic.getRules().size(), is(40));
 
     }
 

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
@@ -66,6 +66,6 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
     void if_this_test_fails_needs_updating_with_your_changes() {
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(69));
+        assertThat(logic.getRules().size(), is(70));
     }
 }

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
@@ -58,6 +58,14 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
                     "name", "Transfer Case Offline",
                     "processCategories","defaultJudgment"
                 )
+            ),
+            Arguments.of(
+                "CONTACT_INFORMATION_UPDATED_WA", "",
+                Map.of(
+                    "taskId", "UpdateDetailsInCasemanSystem",
+                    "name", "Update details in Caseman",
+                    "processCategories","routineWork"
+                )
             )
         );
     }

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaPermissionTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaPermissionTest.java
@@ -405,4 +405,37 @@ class CamundaTaskWaPermissionTest extends DmnDecisionTableBaseUnitTest {
         )));
 
     }
+
+    @SuppressWarnings("checkstyle:indentation")
+    @ParameterizedTest
+    @CsvSource(value = {
+        "UpdateDetailsInCasemanSystem"
+    })
+    void given_UpdateDetailsInCasemanSystem_taskType_when_evaluate_dmn_then_it_returns_expected_rule(String taskType) {
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("taskAttributes", Map.of("taskType", taskType));
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        MatcherAssert.assertThat(dmnDecisionTableResult.getResultList(), is(List.of(
+            Map.of(
+                "name", "task-supervisor",
+                "value", "Read,Manage,Cancel,Unassign,Assign",
+                "autoAssignable", false
+            ),
+            Map.of(
+                "name", "hearing-centre-admin",
+                "value", "Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn",
+                "roleCategory", "ADMIN",
+                "autoAssignable", false
+            ),
+            Map.of(
+                "name", "hearing-centre-team-leader",
+                "value", "Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn",
+                "roleCategory", "ADMIN",
+                "autoAssignable", true
+            )
+        )));
+
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-9754


### Change description ###
- WA Task Configuration for notifying a caseworker for updated case data (Reminder to Update Caseman)

**Initiation**
<img width="949" alt="image" src="https://github.com/hmcts/civil-wa-task-configuration/assets/95024266/7112a021-e85e-41d5-8f2c-966fb2168578">
<img width="817" alt="image" src="https://github.com/hmcts/civil-wa-task-configuration/assets/95024266/38c3acbf-30f3-4b22-b692-afffe7083fb1">

**Configuration**
<img width="944" alt="image" src="https://github.com/hmcts/civil-wa-task-configuration/assets/95024266/94f7e649-cbef-4053-af16-7c2af8e488c0">
<img width="790" alt="image" src="https://github.com/hmcts/civil-wa-task-configuration/assets/95024266/0a42c598-be02-4511-b5c9-aa9d2e385cb9">

**Permissions**
<img width="954" alt="image" src="https://github.com/hmcts/civil-wa-task-configuration/assets/95024266/872f7d68-5ba7-4cc4-b23d-7522ffd91606">

**Cancellation**
<img width="988" alt="image" src="https://github.com/hmcts/civil-wa-task-configuration/assets/95024266/66ff8e2b-99fb-48b7-aad1-755090a2d3aa">


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
