### PR TITLE
CIV-0000 - removing redundant WA Task Initiation

### DIFF
--- a/src/main/resources/wa-task-initiation-civil-civil.dmn
+++ b/src/main/resources/wa-task-initiation-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.5.1">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
   <decision id="wa-task-initiation-civil-civil" name="Civil Task initiation DMN">
     <decisionTable id="DecisionTable_0jtevuc" hitPolicy="COLLECT" biodi:annotationsWidth="400">
       <input id="Input_1" label="Event Id" biodi:width="319" camunda:inputVariable="eventId">
@@ -1422,65 +1422,6 @@ else
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0ey2em3">
-          <text>"standardDirectionsOrder"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_1mppe6w">
-        <inputEntry id="UnaryTests_12s0qph">
-          <text>"CLAIMANT_RESPONSE"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1x8c2zz">
-          <text>"JUDICIAL_REFERRAL"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1qzu0y1">
-          <text>&lt;= 100000</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1icdsy2">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1wcl0vh">
-          <text>"SMALL_CLAIM"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1qx6mg9">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1f4mdjp">
-          <text>"ONE_V_TWO_ONE_LEGAL_REP"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1o4hxd4">
-          <text>"FULL_DEFENCE"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1woberv">
-          <text>"FULL_DEFENCE"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0fy90l1">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_17dd4nq">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0yg3nrc">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1wbjskd">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0slr1rl">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_16f6xcx">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1pf8e0i">
-          <text>"LegalAdvisorSmallClaimsTrackDirections"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0kri1g7">
-          <text>"Legal Advisor Small Claims Track Directions"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_14ee2zp">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0ot24lm">
           <text>"standardDirectionsOrder"</text>
         </outputEntry>
       </rule>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
@@ -66,6 +66,6 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
     void if_this_test_fails_needs_updating_with_your_changes() {
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(69));
+        assertThat(logic.getRules().size(), is(68));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
- Removing redundant WA Task that is causing issues, SPEC SMALL CLAIMS 1v2 initialisation causing issues. 
- This task is unnecesarily duplicated and already being initialised with the rule below

<img width="960" alt="WA-Removal" src="https://github.com/hmcts/civil-wa-task-configuration/assets/33700332/c7761d98-713e-4075-8567-2fc8b0cb7831">
<img width="960" alt="WA-Removal-2" src="https://github.com/hmcts/civil-wa-task-configuration/assets/33700332/d2adc577-ac93-4f02-bf80-105e21ac0efb">
<img width="960" alt="WA-Removal-3" src="https://github.com/hmcts/civil-wa-task-configuration/assets/33700332/8ba8d3ea-c81e-444f-b86e-6cd90921d5ee">


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
