### PR TITLE
CIV-11849 Next hearing details WA

### DIFF
--- a/bin/add-roles.sh
+++ b/bin/add-roles.sh
@@ -33,14 +33,11 @@
 ./bin/utils/ccd-add-role.sh "cui-nbc-profile"
 ./bin/utils/ccd-add-role.sh "citizen-profile"
 ./bin/utils/ccd-add-role.sh "caseworker-civil-citizen-ui-pcqextractor"
-<<<<<<< HEAD
 ./bin/utils/ccd-add-role.sh "next-hearing-date-admin"
-=======
 ./bin/utils/ccd-add-role.sh "judge"
 ./bin/utils/ccd-add-role.sh "hearing-centre-admin"
 ./bin/utils/ccd-add-role.sh "national-business-centre"
 ./bin/utils/ccd-add-role.sh "hearing-centre-team-leader"
->>>>>>> master
 
 roles=("solicitor" "systemupdate" "admin" "staff")
 for role in "${roles[@]}"

--- a/bin/add-roles.sh
+++ b/bin/add-roles.sh
@@ -33,6 +33,7 @@
 ./bin/utils/ccd-add-role.sh "cui-nbc-profile"
 ./bin/utils/ccd-add-role.sh "citizen-profile"
 ./bin/utils/ccd-add-role.sh "caseworker-civil-citizen-ui-pcqextractor"
+./bin/utils/ccd-add-role.sh "next-hearing-date-admin"
 
 roles=("solicitor" "systemupdate" "admin" "staff")
 for role in "${roles[@]}"

--- a/src/main/resources/wa-task-cancellation-civil-civil.dmn
+++ b/src/main/resources/wa-task-cancellation-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-cancellation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.1">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-cancellation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-cancellation-civil-civil" name="Civil Task cancellation DMN">
     <decisionTable id="DecisionTable_0z3jx1ga" hitPolicy="COLLECT">
       <input id="Input_1" label="From State">
@@ -280,6 +280,52 @@
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1g2j72i">
+          <text></text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_08ez73e">
+        <inputEntry id="UnaryTests_19tzuc7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0nhbg2u">
+          <text>"UpdateNextHearingInfo"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ky6lpw">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_00g8pgl">
+          <text>"ReConfigure"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1wlf1cz">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0l5h1d0">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0p20zv0">
+          <text></text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0gax61g">
+        <inputEntry id="UnaryTests_1wzxzc2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0e9w2ep">
+          <text>"UPDATE_NEXT_HEARING_DETAILS"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1dgq952">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_06lzhum">
+          <text>"ReConfigure"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_15h9hm9">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0dxb2w9">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0qeer5x">
           <text></text>
         </outputEntry>
       </rule>

--- a/src/main/resources/wa-task-configuration-civil-civil.dmn
+++ b/src/main/resources/wa-task-configuration-civil-civil.dmn
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<<<<<<< Updated upstream
 <definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.3.0">
+=======
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+>>>>>>> Stashed changes
   <decision id="wa-task-configuration-civil-civil" name="Civil Task configuration DMN">
     <decisionTable id="DecisionTable_14cx0791" hitPolicy="COLLECT">
       <input id="InputClause_1gxyo7fa" label="CCD Case Data" camunda:inputVariable="caseData">
@@ -1231,6 +1235,7 @@ else ""</text>
           <text>false</text>
         </outputEntry>
       </rule>
+<<<<<<< Updated upstream
       <rule id="DecisionRule_1iuyxr6">
         <inputEntry id="UnaryTests_08fskb3">
           <text></text>
@@ -1288,6 +1293,45 @@ else ""</text>
           <text>"[Online Case Transfer Received]"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_02n6z2u">
+=======
+      <rule id="DecisionRule_1jooibu">
+        <inputEntry id="UnaryTests_09v48j4">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06bhm99">
+          <text>"Prod"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0j98w02">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19zr1xr">
+          <text>"nextHearingId"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1bl5exl">
+          <text>if (caseData != null and caseData.nextHearingDetails !=null and caseData.nextHearingDetails.hearingID !=null) then caseData.nextHearingDetails.hearingID else ""</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0tsobxd">
+          <text>true</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0sj54sq">
+        <inputEntry id="UnaryTests_0qy8g8x">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0uktriu">
+          <text>"Prod"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yc8tm1">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1ckjwl3">
+          <text>"nextHearingDate"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1a8vg7r">
+          <text>if (caseData != null and caseData.nextHearingDetails !=null and caseData.nextHearingDetails.hearingDateTime != null) then caseData.nextHearingDetails.hearingDateTime else ""</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_06irwob">
+>>>>>>> Stashed changes
           <text>true</text>
         </outputEntry>
       </rule>

--- a/src/main/resources/wa-task-configuration-civil-civil.dmn
+++ b/src/main/resources/wa-task-configuration-civil-civil.dmn
@@ -1436,7 +1436,7 @@ else ""</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1mo4dmi">
-          <text>"Prod"</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0q37uwo">
           <text></text>
@@ -1456,7 +1456,7 @@ else ""</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0pr08t6">
-          <text>"Prod"</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_14a23s3">
           <text></text>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaCancellationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaCancellationTest.java
@@ -29,7 +29,9 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
     @MethodSource({"scenarioTakesCaseOfflineEventProceedsInHeritageSystem",
         "scenarioTakesCaseOfflineEventProceedsInHeritageSystem_ForReviewCaseFlags",
         "scenarioTakesCaseOfflineEventCaseDismissedSystem", "scenarioProviderRoutineTransfer",
-        "scenarioProviderCaseFlags","scenarioTransferCaseOnlineReconfigure","scenarioRetriggerCasesReconfigure"})
+        "scenarioProviderCaseFlags","scenarioTransferCaseOnlineReconfigure","scenarioRetriggerCasesReconfigure",
+        "scenarioUpdateNextHearingDetailsCasesReconfigure"
+    })
     void given_multiple_event_ids_should_evaluate_dmn(String fromState,
                                                       String eventId,
                                                       String state,
@@ -190,6 +192,22 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
             Arguments.of(
                 "",
                 "RETRIGGER_CASES",
+                "",
+                outcome
+            )
+        );
+    }
+
+    public static Stream<Arguments> scenarioUpdateNextHearingDetailsCasesReconfigure() {
+        List<Map<String, String>> outcome = List.of(
+            Map.of(
+                "action", "ReConfigure"
+            )
+        );
+        return Stream.of(
+            Arguments.of(
+                "",
+                "UPDATE_NEXT_HEARING_DETAILS",
                 "",
                 outcome
             )

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
@@ -1037,6 +1037,39 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
         )));
     }
 
+    @Test
+    void should_reconfigure_next_hearing_id_and_next_hearing_date() {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("applicant1", Map.of(
+            "partyName", "Firstname LastName"
+        ));
+        caseData.put("applicant2", Map.of(
+            "partyName", "Firstname LastName"
+        ));
+        caseData.put("nextHearingDetails", Map.of(
+            "hearingID", "HEARING1234",
+            "hearingDateTime", "2024-01-07T21:36:05"
+        ));
+        caseData.put("featureToggleWA", "HMC");
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("caseData", caseData);
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList().stream()
+            .collect(Collectors.toList());
+
+        assertTrue(workTypeResultList.contains(Map.of(
+            "name", "nextHearingId",
+            "value", "HEARING1234",
+            "canReconfigure", "true"
+        )));
+        assertTrue(workTypeResultList.contains(Map.of(
+            "name", "nextHearingDate",
+            "value", "2024-01-07T21:36:05",
+            "canReconfigure", "true"
+        )));
+    }
+
     private Map<String, String> configDecision(String name, String canReconfigure, String value) {
         return Map.of("name", name, "canReconfigure", canReconfigure,"value", value);
     }

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
@@ -1448,7 +1448,7 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
             "hearingID", "HEARING1234",
             "hearingDateTime", "2024-01-07T21:36:05"
         ));
-        caseData.put("featureToggleWA", "HMC");
+        caseData.put("featureToggleWA", "NHD");
         VariableMap inputVariables = new VariableMapImpl();
         inputVariables.putValue("caseData", caseData);
 
@@ -1477,8 +1477,8 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
         caseData.put("applicant2", Map.of(
             "partyName", "Firstname LastName"
         ));
+        caseData.put("featureToggleWA", "NHD");
 
-        caseData.put("featureToggleWA", "HMC");
         VariableMap inputVariables = new VariableMapImpl();
         inputVariables.putValue("caseData", caseData);
 

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
@@ -1401,6 +1401,36 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
         )));
     }
 
+    @Test
+    void should_reconfigure_next_hearing_id_and_next_hearing_date_as_empty() {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("applicant1", Map.of(
+            "partyName", "Firstname LastName"
+        ));
+        caseData.put("applicant2", Map.of(
+            "partyName", "Firstname LastName"
+        ));
+
+        caseData.put("featureToggleWA", "HMC");
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("caseData", caseData);
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList().stream()
+            .collect(Collectors.toList());
+
+        assertTrue(workTypeResultList.contains(Map.of(
+            "name", "nextHearingId",
+            "value", "",
+            "canReconfigure", "true"
+        )));
+        assertTrue(workTypeResultList.contains(Map.of(
+            "name", "nextHearingDate",
+            "value", "",
+            "canReconfigure", "true"
+        )));
+    }
+
     private Map<String, String> configDecision(String name, String canReconfigure, String value) {
         return Map.of("name", name, "canReconfigure", canReconfigure, "value", value);
     }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-10981

- Mapped nextHearingId and nextHearingDate task fields data field and enabled reconfiguration of task data on NEXT_HEARING_DATE_UPDATE and UpdateNextHearingInfo events.

![Screenshot 2024-02-13 at 15 17 53](https://github.com/hmcts/civil-wa-task-configuration/assets/90632240/0ec8db62-0246-48a1-9b5d-672c627aee23)

![Screenshot 2024-02-13 at 15 16 04](https://github.com/hmcts/civil-wa-task-configuration/assets/90632240/0938b66c-617e-4b42-816e-776b80d7704d)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
