### PR TITLE
CIV-9754 - Added WA task configuration for manage party details

### DIFF
--- a/src/main/resources/wa-task-cancellation-civil-civil.dmn
+++ b/src/main/resources/wa-task-cancellation-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-cancellation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.3.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-cancellation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-cancellation-civil-civil" name="Civil Task cancellation DMN">
     <decisionTable id="DecisionTable_0z3jx1ga" hitPolicy="COLLECT">
       <input id="Input_1" label="From State">
@@ -305,6 +305,54 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_0wwcy0l">
           <text>"decisionOnReconsideration"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_093uqnn">
+        <description>"If a case is moved offline, then all "caseProgression" tasks should be cancelled"</description>
+        <inputEntry id="UnaryTests_1mcq8b0">
+          <text>"CASE_DISMISSED"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ggm09t">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1018ebn">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1pjrbzj">
+          <text>"Cancel"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0b6yoio">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_173s7ah">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0hcgc7f">
+          <text>"updateContactInformation"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0t72co3">
+        <description>"If a case is moved offline, then all "caseProgression" tasks should be cancelled"</description>
+        <inputEntry id="UnaryTests_0i5coaq">
+          <text>"PROCEEDS_IN_HERITAGE_SYSTEM"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1nsjljs">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0utcyej">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1s8c7uy">
+          <text>"Cancel"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1yqbukt">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ebng5e">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0vkxqs2">
+          <text>"updateContactInformation"</text>
         </outputEntry>
       </rule>
     </decisionTable>

--- a/src/main/resources/wa-task-completion-civil-civil.dmn
+++ b/src/main/resources/wa-task-completion-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-completion-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.15.2">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-completion-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-completion-civil-civil" name="Civil  Task completion DMN">
     <decisionTable id="DecisionTable_01re27ma" hitPolicy="COLLECT">
       <input id="eventId" label="Event ID" biodi:width="614">
@@ -388,6 +388,17 @@
           <text>"ScheduleAHearing"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_04h3g6f">
+          <text>"Auto"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0jpd0tf">
+        <inputEntry id="UnaryTests_0o19pg9">
+          <text>"ADD_CASE_NOTE"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1djt5c1">
+          <text>"UpdateDetailsInCasemanSystem"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0h0iyfa">
           <text>"Auto"</text>
         </outputEntry>
       </rule>

--- a/src/main/resources/wa-task-configuration-civil-civil.dmn
+++ b/src/main/resources/wa-task-configuration-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.15.1">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-configuration-civil-civil" name="Civil Task configuration DMN">
     <decisionTable id="DecisionTable_14cx0791" hitPolicy="COLLECT">
       <input id="InputClause_1gxyo7fa" label="CCD Case Data" camunda:inputVariable="caseData">
@@ -1428,6 +1428,46 @@ else ""</text>
           <text>"[Fast Track Directions - NIHL](/cases/case-details/${[CASE_REFERENCE]}/trigger/CREATE_SDO/CREATE_SDOFastTrack)&lt;br /&gt;&lt;br /&gt;[Not Suitable for SDO](/cases/case-details/${[CASE_REFERENCE]}/trigger/NotSuitable_SDO/NotSuitable_SDONotSuitableSDO)"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0cwjo7k">
+          <text>true</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0g9oy75">
+        <inputEntry id="UnaryTests_1o9jjfk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0td321c">
+          <text>"MCI"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1u8bnj2">
+          <text>"UpdateDetailsInCasemanSystem"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1p9adt6">
+          <text>"roleCategory"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1asx3py">
+          <text>"ADMIN"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0h50006">
+          <text>true</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0pgwrmk">
+        <inputEntry id="UnaryTests_0jdynsl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0a7fy1d">
+          <text>"MCI"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1v9lm65">
+          <text>"UpdateDetailsInCasemanSystem"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_13slnhy">
+          <text>"workType"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_19ii6n4">
+          <text>"routine_work"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0p4grt3">
           <text>true</text>
         </outputEntry>
       </rule>

--- a/src/main/resources/wa-task-configuration-civil-civil.dmn
+++ b/src/main/resources/wa-task-configuration-civil-civil.dmn
@@ -1471,6 +1471,26 @@ else ""</text>
           <text>true</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_0tipoi5">
+        <inputEntry id="UnaryTests_1eyizrl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1spvht4">
+          <text>"MCI"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0yl44q8">
+          <text>"UpdateDetailsInCasemanSystem"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_14c9n40">
+          <text>"description"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0wvidfs">
+          <text>"[Add a case note](/cases/case-details/${[CASE_REFERENCE]}/trigger/ADD_CASE_NOTE/ADD_CASE_NOTE)"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0253j37">
+          <text>true</text>
+        </outputEntry>
+      </rule>
     </decisionTable>
   </decision>
   <dmndi:DMNDI>

--- a/src/main/resources/wa-task-initiation-civil-civil.dmn
+++ b/src/main/resources/wa-task-initiation-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.15.1">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-initiation-civil-civil" name="Civil Task initiation DMN">
     <decisionTable id="DecisionTable_0jtevuc" hitPolicy="COLLECT" biodi:annotationsWidth="400">
       <input id="Input_1" label="Event Id" biodi:width="259" camunda:inputVariable="eventId">
@@ -15091,6 +15091,128 @@ else
         </outputEntry>
         <outputEntry id="LiteralExpression_0l85gxv">
           <text>"standardDirectionsOrder"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1fpsvnt">
+        <inputEntry id="UnaryTests_0664xcb">
+          <text>"CONTACT_INFORMATION_UPDATED_WA"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uxzvlt">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1lryfqg">
+          <text>"MCI"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0x9kbmc">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10kzbq0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0rifla1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qvdize">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_183s7hi">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15osuzq">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04ldy0c">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1rsio6z">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1im59ga">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0cekqpz">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0bo46d0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ujbkfd">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1878fxr">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0e4f0bu">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0oa0dr5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0y7jrxd">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03oaus2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qq0mqc">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ja3pwk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1xsnpx9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_02cazm7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1tqlbdf">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0nwdqhn">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04kyshq">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09ln6eb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ew1cxy">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vvwytt">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09ygt1h">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1tkkxrw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13iitwk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1m9lgnp">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_08tbmv4">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0nr3vy8">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0t3k5np">
+          <text>"UpdateDetailsInCasemanSystem"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0i67ng1">
+          <text>"Update details in caseman"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1p3x9yq">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0jyav7u">
+          <text>"updateContactInformation"</text>
         </outputEntry>
       </rule>
     </decisionTable>

--- a/src/main/resources/wa-task-permissions-civil-civil.dmn
+++ b/src/main/resources/wa-task-permissions-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.5.1">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-permissions-civil-civil" name="Civil Permissions DMN">
     <decisionTable id="DecisionTable_1pr5oica" hitPolicy="RULE ORDER">
       <input id="InputClause_12crj6ea" label="Task Type" biodi:width="207" camunda:inputVariable="taskType">
@@ -726,6 +726,72 @@ else
         </outputEntry>
         <outputEntry id="LiteralExpression_0i6i2w3">
           <text>false</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_01v0dox">
+        <description>Listing Officer task permissions</description>
+        <inputEntry id="UnaryTests_0f2wsdm">
+          <text>"UpdateDetailsInCasemanSystem"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lf75gf">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1d58drw">
+          <text>"MCI"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1uuckca">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_102ec2w">
+          <text>"hearing-centre-admin"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_07yznqb">
+          <text>"Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1n6aef0">
+          <text>"ADMIN"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0fw4f7k">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1gvpvng">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1m6oesj">
+          <text>false</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1cwm4m8">
+        <description>Access request for Listing Officers</description>
+        <inputEntry id="UnaryTests_1oqmxu8">
+          <text>"UpdateDetailsInCasemanSystem"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09yhbu6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0z46az1">
+          <text>"MCI"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1bzxv94">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0lkeit9">
+          <text>"hearing-centre-team-leader"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_12sr588">
+          <text>"Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_133wwff">
+          <text>"ADMIN"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1nn00t8">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1lhga91">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0u5c30f">
+          <text>true</text>
         </outputEntry>
       </rule>
     </decisionTable>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskCompletionTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskCompletionTest.java
@@ -182,6 +182,10 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
                     Map.of(
                         "taskType", "ScheduleAHearing",
                         "completionMode", "Auto"
+                    ),
+                    Map.of(
+                        "taskType", "UpdateDetailsInCasemanSystem",
+                        "completionMode", "Auto"
                     )
                 )
             )
@@ -286,6 +290,6 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
 
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(32));
+        assertThat(logic.getRules().size(), is(33));
     }
 }

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaCancellationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaCancellationTest.java
@@ -102,6 +102,10 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
             Map.of(
                 "action", "Cancel",
                 "processCategories", "decisionOnReconsideration"
+            ),
+            Map.of(
+                "action", "Cancel",
+                "processCategories", "updateContactInformation"
             )
         );
         return Stream.of(
@@ -133,6 +137,10 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
             Map.of(
                 "action", "Cancel",
                 "processCategories", "decisionOnReconsideration"
+            ),
+            Map.of(
+                "action", "Cancel",
+                "processCategories", "updateContactInformation"
             )
         );
         return Stream.of(
@@ -152,6 +160,10 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
             Map.of(
                 "action", "Cancel",
                 "processCategories", "reviewCaseFlags"
+            ),
+            Map.of(
+                "action", "Cancel",
+                "processCategories", "updateContactInformation"
             )
         );
         return Stream.of(
@@ -202,6 +214,6 @@ class CamundaTaskWaCancellationTest extends DmnDecisionTableBaseUnitTest {
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
         assertThat(logic.getInputs().size(), is(3));
         assertThat(logic.getOutputs().size(), is(4));
-        assertThat(logic.getRules().size(), is(12));
+        assertThat(logic.getRules().size(), is(14));
     }
 }

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
@@ -1109,6 +1109,42 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
         )));
     }
 
+    @Test
+    void when_taskId_then_return_description_UpdateDetailsInCasemanSystem() {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("applicant1", Map.of(
+            "partyName", "Firstname LastName"
+
+        ));
+        caseData.put("applicant2", Map.of(
+            "partyName", "Firstname LastName"
+
+        ));
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("caseData", caseData);
+        caseData.put("featureToggleWA", "MCI");
+
+        inputVariables.putValue("taskAttributes", Map.of(
+            "taskType",
+            "UpdateDetailsInCasemanSystem"
+        ));
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList().stream()
+            .filter((r) -> r.containsValue("description"))
+            .collect(Collectors.toList());
+
+        System.out.println(workTypeResultList);
+        assertThat(workTypeResultList.size(), is(1));
+
+        assertTrue(workTypeResultList.contains(Map.of(
+            "name", "description",
+            "value", "[Add a case note](/cases/case-details/${[CASE_REFERENCE]}/trigger/ADD_CASE_NOTE/ADD_CASE_NOTE)",
+            "canReconfigure", "true"
+        )));
+    }
+
     private Map<String, String> configDecision(String name, String canReconfigure, String value) {
         return Map.of("name", name, "canReconfigure", canReconfigure,"value", value);
     }

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
@@ -36,7 +36,7 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
 
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(69));
+        assertThat(logic.getRules().size(), is(71));
     }
 
     @SuppressWarnings("checkstyle:indentation")
@@ -1033,6 +1033,78 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
         assertTrue(workTypeResultList.contains(Map.of(
             "name", "workType",
             "value", "routine_work",
+            "canReconfigure", "true"
+        )));
+    }
+
+    @Test
+    void when_taskId_then_return_routine_work_UpdateDetailsInCasemanSystem() {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("applicant1", Map.of(
+            "partyName", "Firstname LastName"
+
+        ));
+        caseData.put("applicant2", Map.of(
+            "partyName", "Firstname LastName"
+
+        ));
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("caseData", caseData);
+        caseData.put("featureToggleWA", "MCI");
+
+        inputVariables.putValue("taskAttributes", Map.of(
+            "taskType",
+            "UpdateDetailsInCasemanSystem"
+        ));
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList().stream()
+            .filter((r) -> r.containsValue("workType"))
+            .collect(Collectors.toList());
+
+        System.out.println(workTypeResultList);
+        assertThat(workTypeResultList.size(), is(1));
+
+        assertTrue(workTypeResultList.contains(Map.of(
+            "name", "workType",
+            "value", "routine_work",
+            "canReconfigure", "true"
+        )));
+    }
+
+    @Test
+    void when_taskId_then_return_roleCategory_UpdateDetailsInCasemanSystem() {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("applicant1", Map.of(
+            "partyName", "Firstname LastName"
+
+        ));
+        caseData.put("applicant2", Map.of(
+            "partyName", "Firstname LastName"
+
+        ));
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("caseData", caseData);
+        caseData.put("featureToggleWA", "MCI");
+
+        inputVariables.putValue("taskAttributes", Map.of(
+            "taskType",
+            "UpdateDetailsInCasemanSystem"
+        ));
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList().stream()
+            .filter((r) -> r.containsValue("roleCategory"))
+            .collect(Collectors.toList());
+
+        System.out.println(workTypeResultList);
+        assertThat(workTypeResultList.size(), is(1));
+
+        assertTrue(workTypeResultList.contains(Map.of(
+            "name", "roleCategory",
+            "value", "ADMIN",
             "canReconfigure", "true"
         )));
     }

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
@@ -543,6 +543,27 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
         assertThat(workTypeResultList.get(0).get("processCategories"), is("decisionOnReconsideration"));
     }
 
+    @Test
+    void when_manage_contact_information_created() {
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("featureToggleWA", "MCI");
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", "CONTACT_INFORMATION_UPDATED_WA");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList
+                       .get(0).get("taskId"), is("UpdateDetailsInCasemanSystem"));
+        assertThat(workTypeResultList.get(0).get("processCategories"), is("updateContactInformation"));
+    }
+
     @ParameterizedTest
     @CsvSource({
         "850,SMALL_CLAIM,standardClaim,CREATE_SDO"
@@ -581,6 +602,6 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
     void if_this_test_fails_needs_updating_with_your_changes() {
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(120));
+        assertThat(logic.getRules().size(), is(121));
     }
 }

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaPermissionTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaPermissionTest.java
@@ -667,6 +667,39 @@ class CamundaTaskWaPermissionTest extends DmnDecisionTableBaseUnitTest {
     @SuppressWarnings("checkstyle:indentation")
     @ParameterizedTest
     @CsvSource(value = {
+            "UpdateDetailsInCasemanSystem"
+    })
+    void given_UpdateDetailsInCasemanSystem_taskType_when_evaluate_dmn_then_it_returns_expected_rule(String taskType) {
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("taskAttributes", Map.of("taskType", taskType));
+        inputVariables.putValue("caseData",Map.of("featureToggleWA", "MCI"));
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        MatcherAssert.assertThat(dmnDecisionTableResult.getResultList(), is(List.of(
+                Map.of(
+                        "name", "task-supervisor",
+                        "autoAssignable", false,
+                        "value", "Read,Manage,Cancel,Unassign,Assign"
+                ),
+                Map.of(
+                        "name", "hearing-centre-admin",
+                        "roleCategory", "ADMIN",
+                        "autoAssignable", false,
+                        "value", "Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn"
+                ),
+                Map.of(
+                        "name", "hearing-centre-team-leader",
+                        "roleCategory", "ADMIN",
+                        "value", "Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn",
+                        "autoAssignable", true
+                )
+        )));
+    }
+
+    @SuppressWarnings("checkstyle:indentation")
+    @ParameterizedTest
+    @CsvSource(value = {
         "NIHLFastTrackDirections"
     })
     void given_NihlFastTrackDirections_taskType_when_evaluate_dmn_then_it_returns_expected_rule(String taskType) {


### PR DESCRIPTION
Change description

 -WA Task Configuration for notifying a caseworker for updated case data (Reminder to Update Caseman)

Initiation
<img width="1771" alt="task-initiation-01" src="https://github.com/hmcts/civil-wa-task-configuration/assets/90632240/37606ad5-4918-476b-bc30-b47cf79874b0">
<img width="1771" alt="task-initiation-02" src="https://github.com/hmcts/civil-wa-task-configuration/assets/90632240/376b2b32-0dd5-4586-9f28-2ab886a6f9c2">

Configuration
<img width="1768" alt="task-configuration" src="https://github.com/hmcts/civil-wa-task-configuration/assets/90632240/44c8c711-293b-4b7f-a53b-9e3728692d7a">

Permissions
<img width="1771" alt="permissions-01" src="https://github.com/hmcts/civil-wa-task-configuration/assets/90632240/635e6084-5a08-4be2-8671-9b2e2bc1deb4">
<img width="1776" alt="permissions-02" src="https://github.com/hmcts/civil-wa-task-configuration/assets/90632240/0dfc7473-0261-4ca5-8ab5-3075452a2680">

Cancellation
<img width="1778" alt="cancelation" src="https://github.com/hmcts/civil-wa-task-configuration/assets/90632240/d2c4f58d-3581-4df0-a41f-b6f0221daad1">


Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x] No