### PR TITLE
CIV-0000 Test tag update

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -142,7 +142,7 @@ withPipeline(type, product, component) {
     yarnBuilder.yarn('install-dependencies')
   }
 
-  afterSuccess('smoketest:preview') {
+  afterAlways('smoketest:preview') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'test-results/smokeTest/**/*'
   }
 
@@ -150,7 +150,7 @@ withPipeline(type, product, component) {
     uploadDmnDiagrams('preview',"${CHANGE_ID}")
   }
 
-  afterSuccess('functionalTest:preview') {
+  afterAlways('functionalTest:preview') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'test-results/functional/**/*'
   }
 
@@ -169,7 +169,7 @@ withPipeline(type, product, component) {
     yarnBuilder.yarn('install-dependencies')
   }
 
-  afterSuccess('smoketest:aat') {
+  afterAlways('smoketest:aat') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'test-results/smokeTest/**/*'
   }
 
@@ -181,6 +181,9 @@ withPipeline(type, product, component) {
   afterSuccess('functionalTest:aat') {
     //Release dmns on to prod
     uploadDmnDiagrams('prod', '')
+  }
+
+  afterAlways('functionalTest:aat') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'test-results/functional/**/*'
   }
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -8,7 +8,7 @@ def component = "task-configuration"
 def s2sServiceName = "wa_camunda_pipeline_upload"
 def branchesToSync = ['demo', 'perftest','ithc']
 def product = "civil"
-def ccdBranch = "master"
+def ccdBranch = "Fix-wa-test"
 def camundaBranch = "master"
 
 def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -8,7 +8,7 @@ def component = "task-configuration"
 def s2sServiceName = "wa_camunda_pipeline_upload"
 def branchesToSync = ['demo', 'perftest','ithc']
 def product = "civil"
-def ccdBranch = "Fix-wa-test"
+def ccdBranch = "master"
 def camundaBranch = "master"
 
 def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -32,7 +32,7 @@ def type = "java"
 def product = "civil"
 def component = "task-configuration"
 def s2sServiceName = "wa_camunda_pipeline_upload"
-def ccdBranch = "master"
+def ccdBranch = "Fix-wa-test"
 
 def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)
 
@@ -84,6 +84,7 @@ withNightlyPipeline(type, product, component) {
     """
     yarnBuilder.yarn('yarn-update')
     yarnBuilder.yarn('install-dependencies')
+    yarnBuilder.yarn('playwright install')
   }
 
   afterAlways('fullFunctionalTest') {

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -32,7 +32,7 @@ def type = "java"
 def product = "civil"
 def component = "task-configuration"
 def s2sServiceName = "wa_camunda_pipeline_upload"
-def ccdBranch = "Fix-wa-test"
+def ccdBranch = "master"
 
 def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)
 

--- a/build.gradle
+++ b/build.gradle
@@ -156,26 +156,7 @@ task runSmokeTests(type: Exec, description: 'Runs smoke tests.') {
   commandLine '/usr/bin/yarn', '--silent','run' , 'test:smoke'
 }
 
-task runApiTests(type: Exec, description: 'Runs Api WA functional tests.') {
-  onlyIf {
-    return System.env.NIGHTLY_RUN != 'true'
-  }
-  commandLine '/usr/bin/yarn', '--silent','run' , 'test:api-1v1'
-}
-
-task runWATests(type: Exec, description: 'Runs Api WA functional tests.') {
-  onlyIf {
-    return System.env.ENVIRONMENT == 'preview'
-  }
-  commandLine '/usr/bin/yarn', '--silent','run' , 'test:api-dj'
-}
-
-
-
-task runNightlyCivilCCDTaskTests(type: Exec, description: 'Runs Api WA functional tests.') {
-  onlyIf {
-    return System.env.NIGHTLY_RUN == 'true'
-  }
+task runCivilCCDTaskTests(type: Exec, description: 'Runs Api WA functional tests.') {
   commandLine '/usr/bin/yarn', '--silent', 'run' , 'test:wa-r4'
 }
 
@@ -198,7 +179,7 @@ task smoke(description: 'Runs the smoke tests.') {
 }
 
 task functional(description: 'Runs the functional tests.') {
-  dependsOn(inStrictOrder(awaitApplicationReadiness, runApiTests, runNightlyCivilCCDTaskTests,
+  dependsOn(inStrictOrder(awaitApplicationReadiness, runCivilCCDTaskTests,
   pullGeneralAppAsset, runNightlyGenAppCCDTaskTests))
 }
 


### PR DESCRIPTION
When we first written the tests, task tests were not in master So we were running api 1v1 test but now that task functionality is live we can run same tests in nightly and master. Based on the RUN_WA_API_TEST flag it will verify the task