### PR TITLE
CIV-12735 refer to judge event

### DIFF
--- a/src/main/resources/wa-task-completion-civil-civil.dmn
+++ b/src/main/resources/wa-task-completion-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-completion-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.9.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-completion-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-completion-civil-civil" name="Civil  Task completion DMN">
     <decisionTable id="DecisionTable_01re27ma" hitPolicy="COLLECT">
       <input id="eventId" label="Event ID" biodi:width="614">
@@ -137,6 +137,18 @@
           <text>"LegalAdvisorSmallClaimsTrackDirections"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_14x5qby">
+          <text>"Auto"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0usc2j1">
+        <description>Left empty so event can be triggered without a task</description>
+        <inputEntry id="UnaryTests_1qgzije">
+          <text>"REFER_TO_JUDGE"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0o42w6j">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1erkmgq">
           <text>"Auto"</text>
         </outputEntry>
       </rule>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskCompletionTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskCompletionTest.java
@@ -123,6 +123,9 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
                     Map.of(
                         "taskType", "LegalAdvisorSmallClaimsTrackDirections",
                         "completionMode", "Auto"
+                    ),
+                    Map.of(
+                        "completionMode", "Auto"
                     )
                 )
             )
@@ -317,6 +320,6 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
 
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(34));
+        assertThat(logic.getRules().size(), is(35));
     }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-12735

REFER_TO_JUDGE CCD event not working, as WA was expecting a task, update to allow event without task, as no task exists.

In completion DMN
![image](https://github.com/hmcts/civil-wa-task-configuration/assets/93932689/729ca04f-2bf6-441f-98f1-90a88188577d)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
