### PR TITLE
Updated SLA of trial readiness check ( preHearingContact )

### DIFF
--- a/src/main/resources/wa-task-configuration-civil-civil.dmn
+++ b/src/main/resources/wa-task-configuration-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.5.1">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-configuration-civil-civil" name="Civil Task configuration DMN">
     <decisionTable id="DecisionTable_14cx0791" hitPolicy="COLLECT">
       <input id="InputClause_1gxyo7fa" label="CCD Case Data" camunda:inputVariable="caseData">
@@ -879,7 +879,7 @@ else ""</text>
           <text>"reviewSpecificAccessRequestJudiciary","reviewSpecificAccessRequestAdmin","reviewSpecificAccessRequestLegalOps", "reviewSpecificAccessRequestCTSC","FastTrackDirections",
 "SmallClaimsTrackDirections",
 "LegalAdvisorSmallClaimsTrackDirections",
-"SmallClaimsTrackDirectionsReferral","preHearingContact","adjournedReList","summaryJudgmentDirections","ScheduleAHearing","transferCaseOfflineNotSuitableSDO","reviewSpecificAccessRequestJudiciary","removeHearing","transferCaseOffline","defendantWelshRequest"</text>
+"SmallClaimsTrackDirectionsReferral","adjournedReList","summaryJudgmentDirections","ScheduleAHearing","transferCaseOfflineNotSuitableSDO","reviewSpecificAccessRequestJudiciary","removeHearing","transferCaseOffline","defendantWelshRequest"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0c9u1q1">
           <text>"dueDateIntervalDays"</text>
@@ -1890,6 +1890,26 @@ else ""</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_01efmv7">
           <text>true</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1oev6eg">
+        <inputEntry id="UnaryTests_08021wu">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11a9c06">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1lg67mp">
+          <text>"preHearingContact"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1hix412">
+          <text>"dueDateIntervalDays"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_15ga4xa">
+          <text>7</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1u21mi4">
+          <text>false</text>
         </outputEntry>
       </rule>
     </decisionTable>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
@@ -36,7 +36,7 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
 
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(92));
+        assertThat(logic.getRules().size(), is(93));
     }
 
     @SuppressWarnings("checkstyle:indentation")


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-13297

Updated SLA of preHearingContact from 20 to 7

removed from 
![image](https://github.com/hmcts/civil-wa-task-configuration/assets/93932689/e79a5e58-79b9-4cbd-8b00-b97a24f1df9f)

And added to 
![image](https://github.com/hmcts/civil-wa-task-configuration/assets/93932689/e2031d70-9913-4ff1-aa90-f663af81300a)



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
