### PR TITLE
CIV-14269 HMC Early Adopters

### DIFF
--- a/src/main/resources/wa-task-configuration-civil-civil.dmn
+++ b/src/main/resources/wa-task-configuration-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.15.1">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-configuration-civil-civil" name="Civil Task configuration DMN">
     <decisionTable id="DecisionTable_14cx0791" hitPolicy="COLLECT">
       <input id="InputClause_1gxyo7fa" label="CCD Case Data" camunda:inputVariable="caseData">
@@ -1666,7 +1666,7 @@ else ""</text>
           <text>"description"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1793apd">
-          <text>if (caseData != null and caseData.hmcEaCourtLocation != null) then "[Schedule a hearing using the Hearings tab](/cases/case-details/${[CASE_REFERENCE]}/hearings)" else "[Directions - Schedule A Hearing](/cases/case-details/${[CASE_REFERENCE]}/trigger/HEARING_SCHEDULED/HEARING_SCHEDULEDHearingNoticeSelect)"</text>
+          <text>if (caseData != null and caseData.hmcEaCourtLocation != null and caseData.hmcEaCourtLocation = "Yes") then "[Schedule a hearing using the Hearings tab](/cases/case-details/${[CASE_REFERENCE]}/hearings)" else "[Directions - Schedule A Hearing](/cases/case-details/${[CASE_REFERENCE]}/trigger/HEARING_SCHEDULED/HEARING_SCHEDULEDHearingNoticeSelect)"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0da9njz">
           <text>true</text>
@@ -1926,7 +1926,7 @@ else ""</text>
           <text>"description"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1jnz3uw">
-          <text>if (caseData != null and caseData.hmcEaCourtLocation != null) then "[Schedule a hearing using the Hearings tab](/cases/case-details/${[CASE_REFERENCE]}/hearings)" else "[Case Adjourned - Relist Hearing](/cases/case-details/${[CASE_REFERENCE]}/trigger/HEARING_SCHEDULED/HEARING_SCHEDULEDHearingNoticeSelect)"</text>
+          <text>if (caseData != null and caseData.hmcEaCourtLocation != null and caseData.hmcEaCourtLocation = "Yes") then "[Schedule a hearing using the Hearings tab](/cases/case-details/${[CASE_REFERENCE]}/hearings)" else "[Case Adjourned - Relist Hearing](/cases/case-details/${[CASE_REFERENCE]}/trigger/HEARING_SCHEDULED/HEARING_SCHEDULEDHearingNoticeSelect)"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1edun9j">
           <text>false</text>

--- a/src/main/resources/wa-task-configuration-civil-civil.dmn
+++ b/src/main/resources/wa-task-configuration-civil-civil.dmn
@@ -1677,7 +1677,7 @@ else ""</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0td321c">
-          <text>"MCI"</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1u8bnj2">
           <text>"UpdateDetailsInCasemanSystem"</text>
@@ -1697,7 +1697,7 @@ else ""</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0a7fy1d">
-          <text>"MCI"</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1v9lm65">
           <text>"UpdateDetailsInCasemanSystem"</text>
@@ -1717,7 +1717,7 @@ else ""</text>
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1spvht4">
-          <text>"MCI"</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0yl44q8">
           <text>"UpdateDetailsInCasemanSystem"</text>
@@ -1926,7 +1926,7 @@ else ""</text>
           <text>"description"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1jnz3uw">
-          <text>"[Schedule a hearing using the Hearings tab](/cases/case-details/${[CASE_REFERENCE]}/hearings)"</text>
+          <text>if (caseData != null and caseData.hmcEaCourtLocation != null) then "[Schedule a hearing using the Hearings tab](/cases/case-details/${[CASE_REFERENCE]}/hearings)" else "[Case Adjourned - Relist Hearing](/cases/case-details/${[CASE_REFERENCE]}/trigger/HEARING_SCHEDULED/HEARING_SCHEDULEDHearingNoticeSelect)"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1edun9j">
           <text>false</text>

--- a/src/main/resources/wa-task-configuration-civil-civil.dmn
+++ b/src/main/resources/wa-task-configuration-civil-civil.dmn
@@ -1666,7 +1666,7 @@ else ""</text>
           <text>"description"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1793apd">
-          <text>"[Schedule a hearing using the Hearings tab](/cases/case-details/${[CASE_REFERENCE]}/hearings)"</text>
+          <text>if (caseData != null and caseData.hmcEaCourtLocation != null) then "[Schedule a hearing using the Hearings tab](/cases/case-details/${[CASE_REFERENCE]}/hearings)" else "[Directions - Schedule A Hearing](/cases/case-details/${[CASE_REFERENCE]}/trigger/HEARING_SCHEDULED/HEARING_SCHEDULEDHearingNoticeSelect)"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0da9njz">
           <text>true</text>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
@@ -696,7 +696,7 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
     }
 
     @Test
-    void when_taskId_adjourned_relist_then_return_expected_decision() {
+    void when_taskId_adjourned_relist_and_hmc_ea_yes_then_return_expected_decision() {
         Map<String, Object> caseData = new HashMap<>();
         caseData.put("applicant1", Map.of(
             "partyName", "Firstname LastName"
@@ -707,6 +707,7 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
 
         ));
 
+        caseData.put("hmcEaCourtLocation", "Yes");
         caseData.put("featureToggleWA", "HMC");
 
         VariableMap inputVariables = new VariableMapImpl();
@@ -721,12 +722,13 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
         assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
             "canReconfigure", "false",
             "name", "description",
-            "value", "[Schedule a hearing using the Hearings tab](/cases/case-details/${[CASE_REFERENCE]}/hearings)"
+            "value", "[Schedule a hearing using the Hearings tab]"
+                + "(/cases/case-details/${[CASE_REFERENCE]}/hearings)"
         )));
     }
 
     @Test
-    void when_taskId_schedule_a_hearing_and_hmc_ea_null_then_return_expected_decision_hmc() {
+    void when_taskId_adjourned_relist_and_hmc_ea_no_then_return_expected_decision() {
         Map<String, Object> caseData = new HashMap<>();
         caseData.put("applicant1", Map.of(
             "partyName", "Firstname LastName"
@@ -734,41 +736,26 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
         ));
         caseData.put("applicant2", Map.of(
             "partyName", "Firstname LastName"
+
         ));
 
+        caseData.put("hmcEaCourtLocation", "No");
         caseData.put("featureToggleWA", "HMC");
 
         VariableMap inputVariables = new VariableMapImpl();
         inputVariables.putValue("caseData", caseData);
         inputVariables.putValue("taskAttributes", Map.of(
             "taskType",
-            "ScheduleAHearing"
+            "adjournedReList"
         ));
 
         DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
 
         assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
-            "canReconfigure", "true",
+            "canReconfigure", "false",
             "name", "description",
-            "value", "[Directions - Schedule A Hearing](/cases/case-details/"
-                + "${[CASE_REFERENCE]}/trigger/HEARING_SCHEDULED/HEARING_SCHEDULEDHearingNoticeSelect)"
-        )));
-
-        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
-            "canReconfigure", "true",
-            "name", "workType",
-            "value", "hearing_work"
-        )));
-
-        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
-            "canReconfigure", "true",
-            "name", "roleCategory",
-            "value", "ADMIN"
-        )));
-
-        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
-            "name", "dueDateIntervalDays",
-            "value", "20"
+            "value", "[Case Adjourned - Relist Hearing](/cases/case-details/${[CASE_REFERENCE]}"
+                + "/trigger/HEARING_SCHEDULED/HEARING_SCHEDULEDHearingNoticeSelect)"
         )));
     }
 

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
@@ -728,6 +728,37 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
     }
 
     @Test
+    void when_taskId_adjourned_relist_and_hmc_ea_null_then_return_expected_decision() {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("applicant1", Map.of(
+            "partyName", "Firstname LastName"
+
+        ));
+        caseData.put("applicant2", Map.of(
+            "partyName", "Firstname LastName"
+
+        ));
+
+        caseData.put("featureToggleWA", "HMC");
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("caseData", caseData);
+        inputVariables.putValue("taskAttributes", Map.of(
+            "taskType",
+            "adjournedReList"
+        ));
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
+            "canReconfigure", "false",
+            "name", "description",
+            "value", "[Case Adjourned - Relist Hearing](/cases/case-details/${[CASE_REFERENCE]}"
+                + "/trigger/HEARING_SCHEDULED/HEARING_SCHEDULEDHearingNoticeSelect)"
+        )));
+    }
+
+    @Test
     void when_taskId_adjourned_relist_and_hmc_ea_no_then_return_expected_decision() {
         Map<String, Object> caseData = new HashMap<>();
         caseData.put("applicant1", Map.of(
@@ -808,7 +839,55 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
     }
 
     @Test
-    void when_taskId_schedule_a_hearing_ea_hmc_no_then_return_expected_decision_hmc() {
+    void when_taskId_schedule_a_hearing_hmc_ea_no_then_return_expected_decision_hmc() {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("applicant1", Map.of(
+            "partyName", "Firstname LastName"
+
+        ));
+        caseData.put("applicant2", Map.of(
+            "partyName", "Firstname LastName"
+        ));
+
+        caseData.put("featureToggleWA", "HMC");
+        caseData.put("hmcEaCourtLocation", "No");
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("caseData", caseData);
+        inputVariables.putValue("taskAttributes", Map.of(
+            "taskType",
+            "ScheduleAHearing"
+        ));
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
+            "canReconfigure", "true",
+            "name", "description",
+            "value", "[Directions - Schedule A Hearing](/cases/case-details/"
+                + "${[CASE_REFERENCE]}/trigger/HEARING_SCHEDULED/HEARING_SCHEDULEDHearingNoticeSelect)"
+        )));
+
+        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
+            "canReconfigure", "true",
+            "name", "workType",
+            "value", "hearing_work"
+        )));
+
+        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
+            "canReconfigure", "true",
+            "name", "roleCategory",
+            "value", "ADMIN"
+        )));
+
+        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
+            "name", "dueDateIntervalDays",
+            "value", "20"
+        )));
+    }
+
+    @Test
+    void when_taskId_schedule_a_hearing_hmc_ea_null_then_return_expected_decision_hmc() {
         Map<String, Object> caseData = new HashMap<>();
         caseData.put("applicant1", Map.of(
             "partyName", "Firstname LastName"

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
@@ -726,7 +726,7 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
     }
 
     @Test
-    void when_taskId_schedule_a_hearing_then_return_expected_decision_hmc() {
+    void when_taskId_schedule_a_hearing_and_hmc_ea_null_then_return_expected_decision_hmc() {
         Map<String, Object> caseData = new HashMap<>();
         caseData.put("applicant1", Map.of(
             "partyName", "Firstname LastName"
@@ -734,7 +734,6 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
         ));
         caseData.put("applicant2", Map.of(
             "partyName", "Firstname LastName"
-
         ));
 
         caseData.put("featureToggleWA", "HMC");
@@ -751,7 +750,104 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
         assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
             "canReconfigure", "true",
             "name", "description",
-            "value", "[Schedule a hearing using the Hearings tab](/cases/case-details/${[CASE_REFERENCE]}/hearings)"
+            "value", "[Directions - Schedule A Hearing](/cases/case-details/"
+                + "${[CASE_REFERENCE]}/trigger/HEARING_SCHEDULED/HEARING_SCHEDULEDHearingNoticeSelect)"
+        )));
+
+        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
+            "canReconfigure", "true",
+            "name", "workType",
+            "value", "hearing_work"
+        )));
+
+        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
+            "canReconfigure", "true",
+            "name", "roleCategory",
+            "value", "ADMIN"
+        )));
+
+        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
+            "name", "dueDateIntervalDays",
+            "value", "20"
+        )));
+    }
+
+    @Test
+    void when_taskId_schedule_a_hearing_and_hmc_ea_yes_then_return_expected_decision_hmc() {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("applicant1", Map.of(
+            "partyName", "Firstname LastName"
+
+        ));
+        caseData.put("applicant2", Map.of(
+            "partyName", "Firstname LastName"
+        ));
+
+        caseData.put("featureToggleWA", "HMC");
+        caseData.put("hmcEaCourtLocation", "Yes");
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("caseData", caseData);
+        inputVariables.putValue("taskAttributes", Map.of(
+            "taskType",
+            "ScheduleAHearing"
+        ));
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
+            "canReconfigure", "true",
+            "name", "description",
+            "value", "[Schedule a hearing using the Hearings tab]"
+                + "(/cases/case-details/${[CASE_REFERENCE]}/hearings)"
+        )));
+
+        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
+            "canReconfigure", "true",
+            "name", "workType",
+            "value", "hearing_work"
+        )));
+
+        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
+            "canReconfigure", "true",
+            "name", "roleCategory",
+            "value", "ADMIN"
+        )));
+
+        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
+            "name", "dueDateIntervalDays",
+            "value", "20"
+        )));
+    }
+
+    @Test
+    void when_taskId_schedule_a_hearing_ea_hmc_no_then_return_expected_decision_hmc() {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("applicant1", Map.of(
+            "partyName", "Firstname LastName"
+
+        ));
+        caseData.put("applicant2", Map.of(
+            "partyName", "Firstname LastName"
+        ));
+
+        caseData.put("featureToggleWA", "HMC");
+        caseData.put("hmcEaCourtLocation", "No");
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("caseData", caseData);
+        inputVariables.putValue("taskAttributes", Map.of(
+            "taskType",
+            "ScheduleAHearing"
+        ));
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
+            "canReconfigure", "true",
+            "name", "description",
+            "value", "[Directions - Schedule A Hearing](/cases/case-details/"
+                + "${[CASE_REFERENCE]}/trigger/HEARING_SCHEDULED/HEARING_SCHEDULEDHearingNoticeSelect)"
         )));
 
         assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
@@ -1296,36 +1392,6 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
                 "name", "description",
                 "value", "[Add a case note](/cases/case-details/${[CASE_REFERENCE]}/trigger"
                         + "/ADD_CASE_NOTE/ADD_CASE_NOTE)"
-        )));
-    }
-
-    @Test
-    void when_taskId_schedule_a_hearing_then_return_expected_decision() {
-        Map<String, Object> caseData = new HashMap<>();
-        caseData.put("applicant1", Map.of(
-            "partyName", "Firstname LastName"
-
-        ));
-        caseData.put("applicant2", Map.of(
-            "partyName", "Firstname LastName"
-
-        ));
-
-        caseData.put("featureToggleWA", "HMC");
-
-        VariableMap inputVariables = new VariableMapImpl();
-        inputVariables.putValue("caseData", caseData);
-        inputVariables.putValue("taskAttributes", Map.of(
-            "taskType",
-            "ScheduleAHearing"
-        ));
-
-        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
-
-        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
-            "canReconfigure", "true",
-            "name", "description",
-            "value", "[Schedule a hearing using the Hearings tab](/cases/case-details/${[CASE_REFERENCE]}/hearings)"
         )));
     }
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-14269

-Updated ScheduleHearing task configuration to only show the integrated hearings next steps when hmcEaCourtLocation is set to yes else show the manual hearing next steps.

<img width="1785" alt="Screenshot 2024-06-17 at 09 13 01" src="https://github.com/hmcts/civil-wa-task-configuration/assets/90632240/dc69bee8-6851-4f9a-8a27-a152fd5e9682">
<img width="1781" alt="Screenshot 2024-06-17 at 09 12 00" src="https://github.com/hmcts/civil-wa-task-configuration/assets/90632240/0fa43de3-c7de-47ac-bd06-77d043e40bcc">


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
