### PR TITLE
CIV-14741 Remove completion for schedule a hearing

### DIFF
--- a/src/main/resources/wa-task-completion-civil-civil.dmn
+++ b/src/main/resources/wa-task-completion-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-completion-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.1.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="wa-completion-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.1">
   <decision id="wa-task-completion-civil-civil" name="Civil  Task completion DMN">
     <decisionTable id="DecisionTable_01re27ma" hitPolicy="COLLECT">
       <input id="eventId" label="Event ID" biodi:width="614">
@@ -389,17 +389,6 @@
           <text>"reviewHearingException"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1p7jndx">
-          <text>"Auto"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0a6gvxe">
-        <inputEntry id="UnaryTests_0l9rjxf">
-          <text>"ADD_CASE_NOTE"</text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_0j9ohom">
-          <text>"ScheduleAHearing"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_04h3g6f">
           <text>"Auto"</text>
         </outputEntry>
       </rule>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-14741

### Change description ###

- remove add case note completion for schedule hearing task

master: 
![image](https://github.com/user-attachments/assets/d9fae6c7-1602-44fc-9186-220d68826605)

this pr:
![image](https://github.com/user-attachments/assets/868b4d7f-bd3a-4563-9278-c1eb142468dd)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
Test PR: https://github.com/hmcts/civil-ccd-definition/pull/4660