### PR TITLE
DTSCCI-0000 SNI-6408 Remove standardDirectionsOrder process category identifier

### DIFF
--- a/src/main/resources/wa-task-initiation-civil-civil.dmn
+++ b/src/main/resources/wa-task-initiation-civil-civil.dmn
@@ -27273,7 +27273,7 @@ else
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1vo301s">
-          <text>"standardDirectionsOrder"</text>
+          <text></text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1w6pqnt">
@@ -27437,7 +27437,7 @@ else
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1w1nrva">
-          <text>"standardDirectionsOrder"</text>
+          <text></text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1801kwa">

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
@@ -405,7 +406,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
         assertThat(workTypeResultList.size(), is(1));
         assertThat(workTypeResultList
                        .get(0).get("taskId"), is("transferCaseOfflineNotSuitableSDO"));
-        assertThat(workTypeResultList.get(0).get("processCategories"), is("standardDirectionsOrder"));
+        assertNull(workTypeResultList.get(0).get("processCategories"));
     }
 
     @Test
@@ -611,7 +612,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
         assertThat(workTypeResultList.size(), is(1));
         assertThat(workTypeResultList
                        .get(0).get("taskId"), is("transferCaseOfflineNotSuitableSDO"));
-        assertThat(workTypeResultList.get(0).get("processCategories"), is("standardDirectionsOrder"));
+        assertNull(workTypeResultList.get(0).get("processCategories"));
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SNI-6408

### Change description ###

Remove standardDirectionsOrder process category identifier from transferCaseOfflineNotSuitableSDO task to prevent it from being cancelled when case goes offline

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
