### PR TITLE
CIV-15711 Create WA Task for CaseWorker to Upload Welsh document if judge uncloaks the appln

### DIFF
--- a/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="Definitions_0wgjriw" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.9.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="Definitions_0wgjriw" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.22.0">
   <decision id="wa-task-initiation-civil-generalapplication" name="Civil GA Task initiation DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_141h4ty" hitPolicy="COLLECT" biodi:annotationsWidth="404">
       <input id="Input_1" label="Event Id" camunda:inputVariable="eventId">
@@ -13479,10 +13479,10 @@ or (list contains(additionalData.Data.generalAppType.types, "SUMMARY_JUDGEMENT")
       </rule>
       <rule id="DecisionRule_0meus14">
         <inputEntry id="UnaryTests_0vbsj4v">
-          <text>"MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID"</text>
+          <text>"END_JUDGE_BUSINESS_PROCESS_GASPEC"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0nybjzs">
-          <text>"AWAITING_RESPONDENT_RESPONSE"</text>
+          <text>"APPLICATION_ADD_PAYMENT"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_01hmmc4">
           <text></text>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmnga/CamundaGaSubmissionTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmnga/CamundaGaSubmissionTaskWaInitiationTest.java
@@ -4827,8 +4827,8 @@ public class CamundaGaSubmissionTaskWaInitiationTest extends DmnDecisionTableBas
         Map<String, Object> caseData = new HashMap<>();
         caseData.put("Data", data);
         VariableMap inputVariables = new VariableMapImpl();
-        inputVariables.putValue("eventId", "MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID");
-        inputVariables.putValue("postEventState", "AWAITING_RESPONDENT_RESPONSE");
+        inputVariables.putValue("eventId", "END_JUDGE_BUSINESS_PROCESS_GASPEC");
+        inputVariables.putValue("postEventState", "APPLICATION_ADD_PAYMENT");
         inputVariables.putValue("additionalData", caseData);
         DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
 


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-15711


### Change description ###

if the applicant has the bilingual flag set then the WA task should be triggered at the point the without notice to with notice document is generated so that we can translate it into Welsh for the applicant to understand before deciding whether to make the additional payment

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
