### PR TITLE
CIV-16390 - reviewOrder task no longer end state dependent

### DIFF
--- a/src/main/resources/wa-task-initiation-civil-civil.dmn
+++ b/src/main/resources/wa-task-initiation-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.30.0">
   <decision id="wa-task-initiation-civil-civil" name="Civil Task initiation DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_0jtevuc" hitPolicy="COLLECT" biodi:annotationsWidth="400">
       <input id="Input_1" label="Event Id" biodi:width="259" camunda:inputVariable="eventId">
@@ -34266,6 +34266,186 @@ else
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1avh7xh">
+          <text>"caseProgression"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0d2qqrq">
+        <description>When removing toggle in non-prod, place toggle on line 187. Upon go live, remove toggle from this, and remove line 187.</description>
+        <inputEntry id="UnaryTests_1p4ekf9">
+          <text>"GENERATE_DIRECTIONS_ORDER"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16qw863">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1m8scv2">
+          <text>"CE_B2"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0skwtij">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1k52osq">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0go2bux">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ndne9w">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1kptew3">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vjsix2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ljk1dj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04uwnf2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1hb9ani">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lj0sxd">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11362ey">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1940m00">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bz4kw6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1spvhrm">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1v9ckne">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0m49lb8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03xdr34">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12cvza9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13rtwn3">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ccthyg">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xit1mt">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1clmmgn">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xmps38">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0boq8vn">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hewu1d">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tve7hg">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_041rcye">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hm76et">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0edmlsy">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ho2ksj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0jn1df5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0iz12oh">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0mu1tgn">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_090e86c">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0punn1w">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10kqpsl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_02u5el9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0nr8b02">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04fcb28">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0bv0tjx">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fcymqe">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ds62ay">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vdf27o">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1phelc3">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qg9cvy">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0i2ff8i">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qy527x">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ratzii">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06oz7p5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_172oi45">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1f71roy">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xm9skj">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0ljxg9x">
+          <text>"reviewOrder"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_17ravg7">
+          <text>"Order Made - Review case"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_19mdqpt">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1w0fndl">
           <text>"caseProgression"</text>
         </outputEntry>
       </rule>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
@@ -2447,7 +2447,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
     void if_this_test_fails_needs_updating_with_your_changes() {
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(328));
+        assertThat(logic.getRules().size(), is(329));
     }
 
     @Test
@@ -2687,7 +2687,29 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
                        .get(0).get("name"), is("Remove Hearing - HMC"));
     }
 
+    @Test
+    void generateDirectionsOrder_createOrderReviewTask_anyEndState() {
 
+        Map<String, Object> data = new HashMap<>();
+        data.put("featureToggleWA", "CE_B2");
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", "GENERATE_DIRECTIONS_ORDER");
+        inputVariables.putValue("postEventState", "HEARING_READINESS");
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList
+                       .get(0).get("taskId"), is("reviewOrder"));
+        assertThat(workTypeResultList
+                       .get(0).get("name"), is("Order Made - Review case"));
+    }
 
     private void addNonNullField(Map<String, Object> inputVars, String key, Object value) {
         if (value == null || (value instanceof String && ((String) value).trim().isEmpty())) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-16390


### Change description ###
Add initiation line for GENERATE_DIRECTIONS_ORDER that generated reviewOrder irrespective of endstate


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
