### PR TITLE
CIV-16429 - LIP_CLAIM_SETTLED WA Uplift 

### DIFF
--- a/src/main/resources/wa-task-cancellation-civil-civil.dmn
+++ b/src/main/resources/wa-task-cancellation-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-cancellation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.30.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-cancellation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.31.0">
   <decision id="wa-task-cancellation-civil-civil" name="Civil Task cancellation DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_0z3jx1ga" hitPolicy="COLLECT">
       <input id="Input_1" label="From State">

--- a/src/main/resources/wa-task-completion-civil-civil.dmn
+++ b/src/main/resources/wa-task-completion-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-completion-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-completion-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.13.0">
   <decision id="wa-task-completion-civil-civil" name="Civil  Task completion DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_01re27ma" hitPolicy="COLLECT">
       <input id="eventId" label="Event ID" biodi:width="614">

--- a/src/main/resources/wa-task-completion-civil-civil.dmn
+++ b/src/main/resources/wa-task-completion-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-completion-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.30.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-completion-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-completion-civil-civil" name="Civil  Task completion DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_01re27ma" hitPolicy="COLLECT">
       <input id="eventId" label="Event ID" biodi:width="614">
@@ -448,18 +448,6 @@
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_123l0oz">
-          <text>"Auto"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0zkvdsx">
-        <description>Event that is completed by the user in ExUI. Values can be listed as comma separated</description>
-        <inputEntry id="UnaryTests_0g954v9">
-          <text>"ADD_CASE_NOTE"</text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1npj5iz">
-          <text>"ClaimSettledRemoveHearing"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1wlcb1m">
           <text>"Auto"</text>
         </outputEntry>
       </rule>

--- a/src/main/resources/wa-task-configuration-civil-civil.dmn
+++ b/src/main/resources/wa-task-configuration-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.31.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-configuration-civil-civil" name="Civil Task configuration DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_14cx0791" hitPolicy="COLLECT">
       <input id="InputClause_1gxyo7fa" label="CCD Case Data" camunda:inputVariable="caseData">
@@ -2093,66 +2093,6 @@ else ""</text>
           <text>true</text>
         </outputEntry>
       </rule>
-      <rule id="DecisionRule_1aq47yn">
-        <inputEntry id="UnaryTests_178h6tq">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1180rj6">
-          <text>"SD"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1xrfbc8">
-          <text>"ClaimSettledRemoveHearing","ClaimDiscontinuedRemoveHearing"</text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1lkapf0">
-          <text>"workType"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1vdbbb2">
-          <text>"hearing_work"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_07z8ujy">
-          <text>true</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0uhoebc">
-        <inputEntry id="UnaryTests_15by0so">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1jj49uw">
-          <text>"SD"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_07w59cu">
-          <text>"ClaimSettledRemoveHearing","ClaimDiscontinuedRemoveHearing"</text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1xwumtg">
-          <text>"roleCategory"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0idxy53">
-          <text>"ADMIN"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0z2thug">
-          <text>true</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_16hhzcj">
-        <inputEntry id="UnaryTests_1840jx8">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1c2655q">
-          <text>"SD"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0g7qn8q">
-          <text>"ClaimSettledRemoveHearing","ClaimDiscontinuedRemoveHearing"</text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_0k2dk7u">
-          <text>"majorPriority"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0x32dpv">
-          <text>3000</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1prdbzu">
-          <text>false</text>
-        </outputEntry>
-      </rule>
       <rule id="DecisionRule_05qduao">
         <inputEntry id="UnaryTests_16alr8p">
           <text></text>
@@ -2161,7 +2101,7 @@ else ""</text>
           <text>"SD"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1nfp18a">
-          <text>"ClaimSettledRemoveHearing","ClaimDiscontinuedRemoveHearing"</text>
+          <text>"ClaimDiscontinuedRemoveHearing"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0wleb3l">
           <text>"description"</text>

--- a/src/main/resources/wa-task-configuration-civil-civil.dmn
+++ b/src/main/resources/wa-task-configuration-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.13.0">
   <decision id="wa-task-configuration-civil-civil" name="Civil Task configuration DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_14cx0791" hitPolicy="COLLECT">
       <input id="InputClause_1gxyo7fa" label="CCD Case Data" camunda:inputVariable="caseData">

--- a/src/main/resources/wa-task-initiation-civil-civil.dmn
+++ b/src/main/resources/wa-task-initiation-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.13.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-initiation-civil-civil" name="Civil Task initiation DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_0jtevuc" hitPolicy="COLLECT" biodi:annotationsWidth="400">
       <input id="Input_1" label="Event Id" biodi:width="259" camunda:inputVariable="eventId">
@@ -54488,7 +54488,7 @@ else
           <text>"removeHearing"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1tbqghz">
-          <text>"Claim Settled - Remove Hearing"</text>
+          <text>"Remove Hearing"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0dm3co0">
           <text></text>
@@ -54670,7 +54670,7 @@ else
           <text>"removeHearing"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1uvzsvr">
-          <text>"Claim Settled - Remove Hearing"</text>
+          <text>"Remove Hearing"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1qrull7">
           <text></text>

--- a/src/main/resources/wa-task-initiation-civil-civil.dmn
+++ b/src/main/resources/wa-task-initiation-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.28.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-initiation-civil-civil" name="Civil Task initiation DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_0jtevuc" hitPolicy="COLLECT" biodi:annotationsWidth="400">
       <input id="Input_1" label="Event Id" biodi:width="259" camunda:inputVariable="eventId">
@@ -54341,7 +54341,7 @@ else
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0b6op5e">
-          <text></text>
+          <text>"FAST_CLAIM"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0ipq7vh">
           <text></text>
@@ -54485,7 +54485,7 @@ else
           <text></text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0jhflju">
-          <text>"ClaimSettledRemoveHearing"</text>
+          <text>"removeHearing"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1tbqghz">
           <text>"Claim Settled - Remove Hearing"</text>
@@ -54494,7 +54494,189 @@ else
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0bsp7si">
-          <text>"RemoveHearing"</text>
+          <text>"caseProgression"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1wktorc">
+        <inputEntry id="UnaryTests_1orszkp">
+          <text>"LIP_CLAIM_SETTLED"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09qqz5v">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jhb1fx">
+          <text>"SD"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12bof45">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zyeza5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13u4gu3">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03orlpi">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_012jese">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1lcc405">
+          <text>"SMALL_CLAIM"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0y214o0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0w2mz8a">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1m96mu2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ty45tr">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ghix8w">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_154pdwx">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fbebf0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_198jtdv">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lsgezs">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09z6f6r">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ee3ph6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0jit9v1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1da16db">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zteddo">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uq2lcm">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wjuhyw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lkggiw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_157h9ht">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1n2cast">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12vj6zs">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0cieail">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qutk32">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1o2swb0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1q5a760">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vc4hoy">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xsl82t">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1rokpis">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0g1pq8o">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mp0rkp">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fgly1y">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1xgifu8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0457gou">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wxie50">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wij6vb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1h54s1n">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0eicqbs">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14v9jcx">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pguqxt">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0yxh0ht">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0o1kyzr">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1rds7rf">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1dyja8k">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wzy24f">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1s606x7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0p0giau">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bn4gi4">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1kure4g">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0wmi0vn">
+          <text>"removeHearing"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1uvzsvr">
+          <text>"Claim Settled - Remove Hearing"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1qrull7">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1i7g9el">
+          <text>"caseProgression"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1lruy76">

--- a/src/main/resources/wa-task-initiation-civil-civil.dmn
+++ b/src/main/resources/wa-task-initiation-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.13.0">
   <decision id="wa-task-initiation-civil-civil" name="Civil Task initiation DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_0jtevuc" hitPolicy="COLLECT" biodi:annotationsWidth="400">
       <input id="Input_1" label="Event Id" biodi:width="259" camunda:inputVariable="eventId">

--- a/src/main/resources/wa-task-permissions-civil-civil.dmn
+++ b/src/main/resources/wa-task-permissions-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.13.0">
   <decision id="wa-task-permissions-civil-civil" name="Civil Permissions DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_1pr5oica" hitPolicy="RULE ORDER">
       <input id="InputClause_12crj6ea" label="Task Type" biodi:width="207" camunda:inputVariable="taskType">

--- a/src/main/resources/wa-task-permissions-civil-civil.dmn
+++ b/src/main/resources/wa-task-permissions-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.30.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-permissions-civil-civil" name="Civil Permissions DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_1pr5oica" hitPolicy="RULE ORDER">
       <input id="InputClause_12crj6ea" label="Task Type" biodi:width="207" camunda:inputVariable="taskType">
@@ -1193,7 +1193,7 @@ else
       <rule id="DecisionRule_0nkyesz">
         <description>Listing Officer task permissions</description>
         <inputEntry id="UnaryTests_11t87u1">
-          <text>"ClaimSettledRemoveHearing","ClaimDiscontinuedRemoveHearing"</text>
+          <text>"ClaimDiscontinuedRemoveHearing"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0li86qd">
           <text></text>
@@ -1226,7 +1226,7 @@ else
       <rule id="DecisionRule_15a57ey">
         <description>Listing Officer task permissions</description>
         <inputEntry id="UnaryTests_0ryam8r">
-          <text>"ClaimSettledRemoveHearing","ClaimDiscontinuedRemoveHearing"</text>
+          <text>"ClaimDiscontinuedRemoveHearing"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1kvv4yn">
           <text></text>

--- a/src/main/resources/wa-task-types-civil-civil.dmn
+++ b/src/main/resources/wa-task-types-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="wa-task-types" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="wa-task-types" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
   <decision id="wa-task-types-civil-civil" name="Civil Task Types DMN">
     <decisionTable id="DecisionTable_17knzal" hitPolicy="COLLECT">
       <input id="Input_1">
@@ -367,18 +367,6 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_1yvwg2v">
           <text>"Defence received in time - order that judgment is set aside"</text>
-        </outputEntry>
-      </rule>
-      <rule id="DecisionRule_0agd7jh">
-        <description>SD</description>
-        <inputEntry id="UnaryTests_0l2k3n9">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_0quhla4">
-          <text>"ClaimSettledRemoveHearing"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0mh0h50">
-          <text>"Claim Settled - Remove Hearing"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0aodz2b">

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskCompletionTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskCompletionTest.java
@@ -239,10 +239,6 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
                         "completionMode", "Auto"
                     ),
                     Map.of(
-                        "taskType", "ClaimSettledRemoveHearing",
-                        "completionMode", "Auto"
-                    ),
-                    Map.of(
                         "taskType", "ClaimDiscontinuedRemoveHearing",
                         "completionMode", "Auto"
                     )
@@ -697,6 +693,6 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
 
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(77));
+        assertThat(logic.getRules().size(), is(76));
     }
 }

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskTypesTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskTypesTest.java
@@ -158,10 +158,6 @@ class CamundaTaskTypesTest extends DmnDecisionTableBaseUnitTest {
                 "taskTypeName", "Defence received in time - order that judgment is set aside"
             ),
             Map.of(
-                "taskTypeId", "ClaimSettledRemoveHearing",
-                "taskTypeName", "Claim Settled - Remove Hearing"
-            ),
-            Map.of(
                 "taskTypeId", "ClaimSettledDivergenceTakeCaseOffline",
                 "taskTypeName", "Claim Settled Divergence - Take Case Offline"
             ),
@@ -389,7 +385,7 @@ class CamundaTaskTypesTest extends DmnDecisionTableBaseUnitTest {
 
         DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
 
-        assertThat(dmnDecisionTableResult.getResultList().size(), is(84));
+        assertThat(dmnDecisionTableResult.getResultList().size(), is(83));
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
@@ -37,7 +37,7 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
 
-        assertThat(logic.getRules().size(), is(169));
+        assertThat(logic.getRules().size(), is(166));
     }
 
     @SuppressWarnings("checkstyle:indentation")
@@ -1767,54 +1767,6 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
     }
 
     @Test
-    void when_taskId_ClaimSettledRemoveHearing_then_return_config() {
-        Map<String, Object> caseData = new HashMap<>();
-        caseData.put("featureToggleWA", "SD");
-        caseData.put("applicant1", Map.of(
-            "partyName", "Firstname LastName"
-        ));
-        caseData.put("applicant2", Map.of(
-            "partyName", "Firstname LastName"
-        ));
-        VariableMap inputVariables = new VariableMapImpl();
-        inputVariables.putValue("caseData", caseData);
-        inputVariables.putValue("taskAttributes", Map.of(
-            "taskType",
-            "ClaimSettledRemoveHearing"
-        ));
-        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
-        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList().stream()
-            .filter((r) -> r.containsValue("workType"))
-            .collect(Collectors.toList());
-
-        System.out.println(workTypeResultList);
-        assertThat(workTypeResultList.size(), is(1));
-        assertTrue(workTypeResultList.contains(Map.of(
-            "name", "workType",
-            "value", "hearing_work",
-            "canReconfigure", "true"
-        )));
-        List<Map<String, Object>> roleCategoryResultList = dmnDecisionTableResult.getResultList().stream()
-            .filter((r) -> r.containsValue("roleCategory"))
-            .collect(Collectors.toList());
-        assertTrue(roleCategoryResultList.contains(Map.of(
-            "name", "roleCategory",
-            "value", "ADMIN",
-            "canReconfigure", "true"
-        )));
-        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
-            "canReconfigure", "false",
-            "name", "majorPriority",
-            "value", "3000"
-        )));
-        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
-            "canReconfigure", "true",
-            "name", "description",
-            "value", "[Remove Hearing](/cases/case-details/${[CASE_REFERENCE]}/trigger/ADD_CASE_NOTE/ADD_CASE_NOTE)"
-        )));
-    }
-
-    @Test
     void when_taskId_ClaimSettledDivergenceTakeCaseOffline_then_return_routine_work_desc() {
 
         Map<String, Object> caseData = new HashMap<>();
@@ -1962,54 +1914,6 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
             "name", "description",
             "value", "[Validate Discontinuance](/cases/case-details/${[CASE_REFERENCE]}/trigger/"
                 + "VALIDATE_DISCONTINUE_CLAIM_CLAIMANT/VALIDATE_DISCONTINUE_CLAIM_CLAIMANT)"
-        )));
-    }
-
-    @Test
-    void when_taskId_ClaimDiscontinuedRemoveHearing_then_return_config() {
-        Map<String, Object> caseData = new HashMap<>();
-        caseData.put("featureToggleWA", "SD");
-        caseData.put("applicant1", Map.of(
-            "partyName", "Firstname LastName"
-        ));
-        caseData.put("applicant2", Map.of(
-            "partyName", "Firstname LastName"
-        ));
-        VariableMap inputVariables = new VariableMapImpl();
-        inputVariables.putValue("caseData", caseData);
-        inputVariables.putValue("taskAttributes", Map.of(
-            "taskType",
-            "ClaimDiscontinuedRemoveHearing"
-        ));
-        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
-        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList().stream()
-            .filter((r) -> r.containsValue("workType"))
-            .collect(Collectors.toList());
-
-        System.out.println(workTypeResultList);
-        assertThat(workTypeResultList.size(), is(1));
-        assertTrue(workTypeResultList.contains(Map.of(
-            "name", "workType",
-            "value", "hearing_work",
-            "canReconfigure", "true"
-        )));
-        List<Map<String, Object>> roleCategoryResultList = dmnDecisionTableResult.getResultList().stream()
-            .filter((r) -> r.containsValue("roleCategory"))
-            .collect(Collectors.toList());
-        assertTrue(roleCategoryResultList.contains(Map.of(
-            "name", "roleCategory",
-            "value", "ADMIN",
-            "canReconfigure", "true"
-        )));
-        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
-            "canReconfigure", "false",
-            "name", "majorPriority",
-            "value", "3000"
-        )));
-        assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(
-            "canReconfigure", "true",
-            "name", "description",
-            "value", "[Remove Hearing](/cases/case-details/${[CASE_REFERENCE]}/trigger/ADD_CASE_NOTE/ADD_CASE_NOTE)"
         )));
     }
 

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
@@ -2448,7 +2448,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
     void if_this_test_fails_needs_updating_with_your_changes() {
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(363));
+        assertThat(logic.getRules().size(), is(364));
     }
 
     @ParameterizedTest
@@ -2481,11 +2481,12 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
     }
 
     @Test
-    void given_lip_claim_settled_create_remove_hearing_task() {
+    void given_lip_claim_settled_create_remove_hearing_task_smallTrack() {
 
         Map<String, Object> data = new HashMap<>();
         data.put("featureToggleWA", "SD");
         data.put("hearingDate", "22-12-2024");
+        data.put("responseClaimTrack", "SMALL_CLAIM");
         Map<String, Object> caseData = new HashMap<>();
         caseData.put("Data", data);
 
@@ -2500,9 +2501,35 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
         assertThat(workTypeResultList.size(), is(1));
         assertThat(
             workTypeResultList
-                .get(0).get("taskId"), is("ClaimSettledRemoveHearing")
+                .get(0).get("taskId"), is("removeHearing")
         );
-        assertThat(workTypeResultList.get(0).get("processCategories"), is("RemoveHearing"));
+        assertThat(workTypeResultList.get(0).get("processCategories"), is("caseProgression"));
+    }
+
+    @Test
+    void given_lip_claim_settled_create_remove_hearing_task_fastTrack() {
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("featureToggleWA", "SD");
+        data.put("hearingDate", "22-12-2024");
+        data.put("responseClaimTrack", "FAST_CLAIM");
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", "LIP_CLAIM_SETTLED");
+        inputVariables.putValue("additionalData", caseData);
+        inputVariables.putValue("postEventState", "");
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(
+            workTypeResultList
+                .get(0).get("taskId"), is("removeHearing")
+        );
+        assertThat(workTypeResultList.get(0).get("processCategories"), is("caseProgression"));
     }
 
     // Temp may return 2 tasks until HMC-NRO cui task uplifts

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaPermissionTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaPermissionTest.java
@@ -934,37 +934,6 @@ class CamundaTaskWaPermissionTest extends DmnDecisionTableBaseUnitTest {
 
     @ParameterizedTest
     @CsvSource(value = {
-        "ClaimSettledRemoveHearing"
-    })
-    void given_ClaimSettledRemoveHearing_taskType_when_evaluate_dmn_then_it_returns_expected_rule(String taskType) {
-        VariableMap inputVariables = new VariableMapImpl();
-        inputVariables.putValue("taskAttributes", Map.of("taskType", taskType));
-        inputVariables.putValue("caseData",Map.of("featureToggleWA", "SD"));
-        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
-
-        MatcherAssert.assertThat(dmnDecisionTableResult.getResultList(), is(List.of(
-            Map.of(
-                "name", "task-supervisor",
-                "autoAssignable", false,
-                "value", "Read,Manage,Cancel,Unassign,Assign"
-            ),
-            Map.of(
-                "name", "hearing-centre-team-leader",
-                "roleCategory", "ADMIN",
-                "autoAssignable", false,
-                "value", "Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn"
-            ),
-            Map.of(
-                "name", "hearing-centre-admin",
-                "roleCategory", "ADMIN",
-                "autoAssignable", false,
-                "value", "Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn"
-            )
-        )));
-    }
-
-    @ParameterizedTest
-    @CsvSource(value = {
         "ClaimSettledDivergenceTakeCaseOffline"
     })
     void given_ClaimDivergenceTakeCaseOffline_taskType_when_evaluate_dmn_then_returns_expected_rule(String taskType) {


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-16429

Changed LIP+CLAIM_SETTLED event to trigger removeHearing task for smsll/fast and removed claimSettledRemoveHearing configuration.

<img width="1783" alt="Screenshot 2025-01-20 at 08 59 45" src="https://github.com/user-attachments/assets/a2a877e0-4dd6-4177-bd85-0f170f7b0954" />
<img width="1779" alt="Screenshot 2025-01-20 at 08 57 27" src="https://github.com/user-attachments/assets/26a9c237-14e3-4737-aa9c-ab7f19cfad0f" />
<img width="1788" alt="Screenshot 2025-01-20 at 08 59 08" src="https://github.com/user-attachments/assets/e0725454-fc06-4f54-a1cc-f155217d6923" />


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
