### PR TITLE
CIV-16552 - Only generate Reschedule when further hearing selected

### DIFF
--- a/src/main/resources/wa-task-initiation-civil-civil.dmn
+++ b/src/main/resources/wa-task-initiation-civil-civil.dmn
@@ -32788,195 +32788,6 @@ else
           <text>"caseProgression"</text>
         </outputEntry>
       </rule>
-      <rule id="DecisionRule_0rc3o4s">
-        <description>When removing toggle in non-prod, place toggle on line 186. Upon go live, remove toggle from this, and remove line 186.</description>
-        <inputEntry id="UnaryTests_1x14ao9">
-          <text>"GENERATE_DIRECTIONS_ORDER"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_18femw7">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0i6lgwf">
-          <text>"CE_B2"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1yx20ty">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_15iwhu0">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0s50pml">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1q3rzey">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0dfkmpd">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1neoxat">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1ixidwq">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1v9hy0q">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_01r10h3">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0h5wsou">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1bl7qws">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0vn10z4">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0o2di4p">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_12b0a8x">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0we32qk">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1xnp3o6">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1alycwq">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0noyqvl">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0qrvjg9">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_05kjb0r">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_129lc7j">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1d1z1vr">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0v76yvj">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0vl4945">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_14zzbce">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0it65pu">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1nga2c3">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0utnfhv">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1jj63m1">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1jwefp2">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0vzxg3k">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1b0w8oi">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1t4lfea">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0v3ss23">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0vfp0ef">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_050p1oz">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1hxoqdx">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_122xs0h">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1rw5ctd">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0s0qcnr">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0i64hud">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1fz1wij">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1iryabu">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1alsjyk">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_02p5yqd">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_13chepj">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1n8y8it">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_17hrkap">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0dr8kon">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1w1jrqv">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1ovkwhz">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1x6zuxa">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_0byfko8">
-          <text></text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_117fmio">
-          <text>true</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_173nyzu">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1f2wk7c">
-          <text>"adjournedReList"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0f20mvi">
-          <text>"Case Adjourned - Re-list Hearing"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1ky10zb">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1xeua1v">
-          <text>"caseProgression"</text>
-        </outputEntry>
-      </rule>
       <rule id="DecisionRule_03fzf7l">
         <inputEntry id="UnaryTests_1u25vf1">
           <text>"GENERATE_DIRECTIONS_ORDER"</text>
@@ -53470,6 +53281,758 @@ else
           <text>"caseProgression"</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_0g35299">
+        <inputEntry id="UnaryTests_0b3pe9y">
+          <text>"GENERATE_DIRECTIONS_ORDER"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1k0h2iu">
+          <text>"CASE_PROGRESSION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1t8wibw">
+          <text>"CE_B2"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fbcahm">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0oqbok4">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11ti0sy">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1t6tdqe">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0w2v0ii">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_07pzkhy">
+          <text>"FAST_CLAIM"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04lr0gz">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vrkfe2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18d01eh">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1w6h83y">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ar1nq5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1leyv5a">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03dgbbv">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06excsb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1cwrnvw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qy82es">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0cj28mx">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1xp0hwk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1npd47s">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0jy7o3v">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_139491a">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0jxoze3">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ci2gp0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0w9w0b5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1f7g85g">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0eh5dua">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jty0bc">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0gersfp">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0osyq7s">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ld1um1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0frg6zt">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1690i5o">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0szd7mf">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0plw38r">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uuadwb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0r3syqw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09jxri8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fqxwks">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_00mral1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qp9kkh">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ewjs14">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qvm6r2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1w94zl8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0be1d39">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15oh7ra">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0738822">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ksxdk7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12a9uab">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_02ctbkn">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_159df9j">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1o5inb4">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0s8xlfw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zibn6b">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1u0js0j">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14nf3w5">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_06uhc6q">
+          <text>"ScheduleHMCHearing"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0wzmrlu">
+          <text>"Reschedule a Fast Track Hearing - HMC"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ezalas">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0hpb0wm">
+          <text>"caseProgression"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1qpjohl">
+        <inputEntry id="UnaryTests_1urmug0">
+          <text>"GENERATE_DIRECTIONS_ORDER"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1583g02">
+          <text>"CASE_PROGRESSION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_135cxlh">
+          <text>"CE_B2"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0aigolw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fwro1x">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1f7pvml">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0us7pyj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1t6vzq4">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0c0xw19">
+          <text>"SMALL_CLAIM"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1378v9z">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kd3t0i">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1a64tes">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1iw10au">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_147iy7z">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qsdivt">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12u1ov9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1y55yxe">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wa76p5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1snbdzz">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1msukta">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yo8ww4">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1xafwta">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06tf4p6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0bj1unq">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1x6wbsc">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18opoz6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14d5hky">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12154li">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0grfmlb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mu7aog">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16m1ftn">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0iaeuq1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1wgex54">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1i63lcm">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ryjdr3">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vvqec9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qlkaql">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1w824a9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qhrhpd">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0b4obc6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1enta0n">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16zhdel">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0s0rqtb">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0q13pn1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pzsb4m">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0cbx724">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1p933oa">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0mewvzl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1wz3j7z">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0mmdrmv">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1rn4zug">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1hel549">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1rh4w14">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1e41bqd">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1id1hny">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0c154ua">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1tt5cz0">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1noob02">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0s0q0zb">
+          <text>"ScheduleHMCHearing"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0iwzzmk">
+          <text>"Reschedule a Small Claims Hearing - HMC"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1svw3ca">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1uocuii">
+          <text>"caseProgression"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1ryhur6">
+        <inputEntry id="UnaryTests_0cghar6">
+          <text>"GENERATE_DIRECTIONS_ORDER"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05lnumc">
+          <text>"CASE_PROGRESSION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xgwo9v">
+          <text>"CE_B2"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pkbua1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1hwfbfk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_037whwr">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04rlw7e">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1dmnqof">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05bkrrl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0yg2omw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0o10f4x">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18hx5pz">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bt32hg">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0amz6ia">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_058asyh">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0flyeg7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0a0ucm1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0l8ra61">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uhosui">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uodcgh">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0log8do">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0guz0bt">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bg7n1s">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1svwyjk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fj91v6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1lfosvg">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0jupym8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qw6f38">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jfi269">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1guvx5l">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0f3glae">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0nkl16r">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03xmc7j">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mwkisw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ouzjdq">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1cpgvpf">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1d5guvp">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13v2gzm">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1oq6unp">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_189uhba">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1lq7pcx">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zkw0hr">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12vgtb0">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0jzic6r">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11qwpke">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0eec81w">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1sl9nnx">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_16xl6aa">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fpdleo">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1skhgke">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1b0200i">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_02vnjum">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03t7k5f">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mdz3ro">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1oo5wli">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ppushm">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kfdza9">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1oa9s3w">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0x3jmlo">
+          <text>"ScheduleHMCHearing"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_12okygn">
+          <text>"Reschedule a Disposal Hearing - HMC"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0w204gz">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1x7tmcm">
+          <text>"caseProgression"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bi80xu">
+        <inputEntry id="UnaryTests_0l7hopn">
+          <text>"GENERATE_DIRECTIONS_ORDER"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1759y9n">
+          <text>"CASE_PROGRESSION"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ctk9y2">
+          <text>"CE_B2"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01ogjrx">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0k2zsrw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1dhua3w">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0inpta6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15mi8fz">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1s7mz2c">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0douwx7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0d2vg9e">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lq9g0p">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0o6lxgx">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zqn5s6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_08ur1ug">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_166wnbm">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_00oz6mf">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0jb71z4">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18j0vgq">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fckngd">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10f8lvt">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0znznnu">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kkwo2s">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1557r7a">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0werthv">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0nr5aq5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03jlqkp">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_08qnb8r">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11bhkkf">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09yt7vn">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1dykgxr">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1eh83ym">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18yg64x">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0p8lwka">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1vmiwt5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1q5tbft">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0o2s243">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1al88j2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zgjr6t">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0iib7h3">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pameu9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bnqrjv">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1kebgof">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06jyojm">
+          <text>"DISPOSAL_HEARING"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0po2jp2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kt1m0m">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tbkmib">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1g3v7hl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0i5orhj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14z97po">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xb9x3j">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13eg3go">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1brxw1i">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ms1sfh">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1erw9t5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0nserda">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19ngdmd">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1wd7twy">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0et4wf0">
+          <text>"ScheduleHMCHearing"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_18e5ugc">
+          <text>"Reschedule a Disposal Hearing - HMC"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_037xq34">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0xyh2j2">
+          <text>"caseProgression"</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_1lruy76">
         <inputEntry id="UnaryTests_0wcryh5">
           <text>"GENERATE_DIRECTIONS_ORDER"</text>
@@ -60426,6 +60989,762 @@ else
           <text>"confirmOrderReviewDismissCase"</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_1xk7zik">
+        <description>Upon CE-B2 release, the 4 live GENERATE_DIRECTIONS_ORDER rules directly beneath these must be removed.</description>
+        <inputEntry id="UnaryTests_0s3yt76">
+          <text>"GENERATE_DIRECTIONS_ORDER"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1f4xg4z">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10l21eu">
+          <text>"CE_B2"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17rlib3">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12rwc4k">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14g2m94">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14bjlqj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05xd3q0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0p3fod1">
+          <text>"SMALL_CLAIM"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yc40im">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0c53ukk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01o1w56">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04g8pyb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0w0g51h">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_07m8ir3">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1s4c2n6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hlzw94">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0elewfi">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ypkoyh">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uvdk06">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1j4rh8j">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jr4tr0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1e98t4f">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ft7x94">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1b7q0o8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0okviz8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0yx143b">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1f269ko">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1rawc2h">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1da0fdq">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0k4qnt6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1xv999y">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0uk6sm7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1v0a7n5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1q0h5tj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0i7ugdx">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0mt0r4f">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_00wq41m">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1js7pg9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ul47yb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_07q1y86">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ge8bg1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xifjlh">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_07jjh4p">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ko1246">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06gll8s">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ka2wg3">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0rymqlt">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14w9rtr">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0y06l0f">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0uhylnn">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1tcdlye">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0cpj1bl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pell64">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0b1inev">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05jp07h">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1c9kmxo">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04kckfg">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_08jrvio">
+          <text>"ScheduleAHearing"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0w6by2d">
+          <text>"Reschedule a Small Claims Hearing"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1t9uyq3">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_10775li">
+          <text>"caseProgression"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1vd0lj4">
+        <description>Upon CE-B2 release, the 4 live GENERATE_DIRECTIONS_ORDER rules directly beneath these must be removed.</description>
+        <inputEntry id="UnaryTests_1955mhu">
+          <text>"GENERATE_DIRECTIONS_ORDER"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lj98fc">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_08bqfbr">
+          <text>"CE_B2"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1f3mgng">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kx6jxx">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1lwmd3j">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vos5bu">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1i60fax">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jtdb3t">
+          <text>"FAST_CLAIM"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15wzwy7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fknrly">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06lviof">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_068jr9o">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0r1ijud">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wu98o7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ctk74d">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0aalbse">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ilq4tr">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0y089e2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ssn41u">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0z8nvto">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1nel6l1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0m3nbty">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1hq3izl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fq1463">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1r2iif7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0cben86">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14kx2ab">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1z0436j">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jeyioa">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kj15qz">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1igmg8w">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0y67ezz">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1llgzb1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0q7394u">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1cvpjcp">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_02ypgz4">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ji5vhh">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_02omf7i">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1s44at8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03969pw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13s6l6l">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0itwlza">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1y5pzne">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0odcesg">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1guti5f">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_178yxpb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qy96p8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05p7657">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0afbzn0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0atvomy">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0yn1lp6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0nipi40">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yr44ys">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1l4okle">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1d7sub0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0z7s8lv">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18gvcz7">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0pdmudg">
+          <text>"ScheduleAHearing"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0qw85v5">
+          <text>"Reschedule a Fast Track Hearing"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_08ifcv0">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0538fgf">
+          <text>"caseProgression"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0to42bq">
+        <description>Upon CE-B2 release, the 4 live GENERATE_DIRECTIONS_ORDER rules directly beneath these must be removed.</description>
+        <inputEntry id="UnaryTests_1om11ar">
+          <text>"GENERATE_DIRECTIONS_ORDER"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1c8vswm">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19wiyq0">
+          <text>"CE_B2"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0k816rf">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yi7yee">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03lqq8w">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01eagxl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18lwp5t">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03zqkv9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_07jw2ly">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ruas2u">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19ohho4">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1oft0k4">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1a2onbw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0i42nrj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04yp772">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1mftdhf">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uucz2h">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1xwqu5r">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1rw2yih">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1iyga1m">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1eqao5t">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0galjio">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ennhma">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0br046d">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0f199a5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ub2q7k">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0j0hwes">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1syuevf">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1amnvtv">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ry7pxk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1hm1ajg">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1965zsh">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0mga7hs">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vu5rtb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bsj6pu">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1j6qznh">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hjedb0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fvaehb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1m12z7a">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0h4vsgv">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_08wyocu">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1a8sh7w">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0m4pmr4">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0t5458p">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09g8hw6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yu7y4g">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04at4ah">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12zuvs1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_02eeawd">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xqeplb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0gqnjbl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0otca98">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qu0gh2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14s3ynd">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12ghmd0">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0yn6gxd">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1nif0rz">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_04a5k6y">
+          <text>"ScheduleAHearing"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_12qg4ra">
+          <text>"Reschedule a Disposal Hearing"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0fql89x">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1qynf5v">
+          <text>"caseProgression"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_15bz5q3">
+        <description>Upon CE-B2 release, the 4 live GENERATE_DIRECTIONS_ORDER rules directly beneath these must be removed.</description>
+        <inputEntry id="UnaryTests_0bh32xu">
+          <text>"GENERATE_DIRECTIONS_ORDER"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18zmlt4">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1dgemk4">
+          <text>"CE_B2"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01ph9zv">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0cwm43z">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hhcwyg">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0q4k63r">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1s514il">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1lh9ehx">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ici7fi">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0an4m4z">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1dimhr9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0dylmmj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10s9c7b">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_14bbofz">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0j0pq34">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1s633lw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1nwq3po">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01d9n23">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0a3dowa">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0s794a6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ffbjik">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1q4cvmd">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1l42xgh">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04vapak">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11fqrcd">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wcdnyz">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03uhext">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0bb1ked">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uhfdkd">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1rgj3ka">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1alnm63">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1lhjjzi">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13mb3km">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qu20s8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05sr9fb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06ufj6h">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0f5w28h">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15ihme1">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10lryy7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0u3ff7t">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yrtvlj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0xbye0o">
+          <text>false</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15ipe7c">
+          <text>"DISPOSAL_HEARING"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0o47h2k">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0znqk6v">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_180n1zj">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_18pv7cm">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_04x9yxi">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1ugon4g">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_037kd98">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tskyv2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0rrouxr">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pime3a">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1sgghrl">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_03pxobt">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1l0pfjf">
+          <text>true</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1os1v72">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_07tqekc">
+          <text>"ScheduleAHearing"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_11dv4y3">
+          <text>"Reschedule a Disposal Hearing"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_13fivvh">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_10vp1s5">
+          <text>"caseProgression"</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_0q6vt4m">
         <inputEntry id="UnaryTests_0rmh596">
           <text>"GENERATE_DIRECTIONS_ORDER"</text>
@@ -65320,7 +66639,7 @@ else
           <text>"GENERATE_DIRECTIONS_ORDER"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1kolljp">
-          <text>"CASE_PROGRESSION"</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_18cfnqx">
           <text>"HMC_LIP"</text>
@@ -65485,7 +66804,7 @@ else
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1f83cbq">
-          <text></text>
+          <text>true</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0y9z8wc">
           <text></text>
@@ -65509,7 +66828,7 @@ else
           <text>"GENERATE_DIRECTIONS_ORDER"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1nenu4e">
-          <text>"CASE_PROGRESSION"</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1bz6bow">
           <text>"HMC_LIP"</text>
@@ -65674,7 +66993,7 @@ else
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0ubzdpc">
-          <text></text>
+          <text>true</text>
         </inputEntry>
         <inputEntry id="UnaryTests_02ok93d">
           <text></text>
@@ -65698,7 +67017,7 @@ else
           <text>"GENERATE_DIRECTIONS_ORDER"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_193du94">
-          <text>"CASE_PROGRESSION"</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0iey5p8">
           <text>"HMC_LIP"</text>
@@ -65863,7 +67182,7 @@ else
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_03ze25t">
-          <text></text>
+          <text>true</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0vde7ck">
           <text></text>
@@ -65887,7 +67206,7 @@ else
           <text>"GENERATE_DIRECTIONS_ORDER"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_096aujq">
-          <text>"CASE_PROGRESSION"</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0yxpirx">
           <text>"HMC_LIP"</text>
@@ -66052,7 +67371,7 @@ else
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0hvq5je">
-          <text></text>
+          <text>true</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0tvxmqc">
           <text></text>

--- a/src/main/resources/wa-task-initiation-civil-civil.dmn
+++ b/src/main/resources/wa-task-initiation-civil-civil.dmn
@@ -53282,6 +53282,7 @@ else
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0g35299">
+        <description>Upon CE-B2 release, the 4 live GENERATE_DIRECTIONS_ORDER rules directly beneath these must be removed.</description>
         <inputEntry id="UnaryTests_0b3pe9y">
           <text>"GENERATE_DIRECTIONS_ORDER"</text>
         </inputEntry>
@@ -53470,6 +53471,7 @@ else
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1qpjohl">
+        <description>Upon CE-B2 release, the 4 live GENERATE_DIRECTIONS_ORDER rules directly beneath these must be removed.</description>
         <inputEntry id="UnaryTests_1urmug0">
           <text>"GENERATE_DIRECTIONS_ORDER"</text>
         </inputEntry>
@@ -53658,6 +53660,7 @@ else
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1ryhur6">
+        <description>Upon CE-B2 release, the 4 live GENERATE_DIRECTIONS_ORDER rules directly beneath these must be removed.</description>
         <inputEntry id="UnaryTests_0cghar6">
           <text>"GENERATE_DIRECTIONS_ORDER"</text>
         </inputEntry>
@@ -53846,6 +53849,7 @@ else
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1bi80xu">
+        <description>Upon CE-B2 release, the 4 live GENERATE_DIRECTIONS_ORDER rules directly beneath these must be removed.</description>
         <inputEntry id="UnaryTests_0l7hopn">
           <text>"GENERATE_DIRECTIONS_ORDER"</text>
         </inputEntry>

--- a/src/main/resources/wa-task-initiation-civil-civil.dmn
+++ b/src/main/resources/wa-task-initiation-civil-civil.dmn
@@ -53287,7 +53287,7 @@ else
           <text>"GENERATE_DIRECTIONS_ORDER"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1k0h2iu">
-          <text>"CASE_PROGRESSION"</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1t8wibw">
           <text>"CE_B2"</text>
@@ -53476,7 +53476,7 @@ else
           <text>"GENERATE_DIRECTIONS_ORDER"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1583g02">
-          <text>"CASE_PROGRESSION"</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_135cxlh">
           <text>"CE_B2"</text>
@@ -53665,7 +53665,7 @@ else
           <text>"GENERATE_DIRECTIONS_ORDER"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_05lnumc">
-          <text>"CASE_PROGRESSION"</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0xgwo9v">
           <text>"CE_B2"</text>
@@ -53854,7 +53854,7 @@ else
           <text>"GENERATE_DIRECTIONS_ORDER"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1759y9n">
-          <text>"CASE_PROGRESSION"</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ctk9y2">
           <text>"CE_B2"</text>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
@@ -3301,7 +3301,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
 
         List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
         //This will be 3 until CE_B2 goes live a pre-existing tasks gets removed.
-        String taskId = applicant1Represented&& respondent1Represented ? "ScheduleHMCHearing" : "ScheduleAHearing";
+        String taskId = applicant1Represented && respondent1Represented ? "ScheduleHMCHearing" : "ScheduleAHearing";
         if (nonNull(furtherHearingRequired)) {
             assertThat(workTypeResultList.size(), is(3));
             assertThat(workTypeResultList.get(0).get("name"), is("Order Made - Review case"));

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
@@ -2260,7 +2260,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
     void if_this_test_fails_needs_updating_with_your_changes() {
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(374));
+        assertThat(logic.getRules().size(), is(377));
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
@@ -1095,32 +1095,6 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
     }
 
     @Test
-    void given_generate_directions_order_event_and_furtherhearingtoggle_should_trigger_task_adjournedReList() {
-        Map<String, Object> data = new HashMap<>();
-        Map<String, Object> caseData = new HashMap<>();
-        data.put("featureToggleWA", "CE_B2");
-        data.put("finalOrderFurtherHearingToggle", List.of("SHOW"));
-        caseData.put("Data", data);
-
-        VariableMap inputVariables = new VariableMapImpl();
-        inputVariables.putValue("eventId", "GENERATE_DIRECTIONS_ORDER");
-        inputVariables.putValue("additionalData", caseData);
-        inputVariables.putValue("postEventState", "CASE_PROGRESSION");
-
-        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
-        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
-
-        //When toggle gets removed from adjournedRelist task, one adjourned task should be deleted here
-        assertThat(workTypeResultList.size(), is(2));
-        assertThat(workTypeResultList
-                       .get(0).get("taskId"), is("adjournedReList"));
-        assertThat(workTypeResultList.get(0).get("processCategories"), is("caseProgression"));
-        assertThat(workTypeResultList
-                       .get(1).get("taskId"), is("reviewOrder"));
-        assertThat(workTypeResultList.get(1).get("processCategories"), is("caseProgression"));
-    }
-
-    @Test
     void when_final_order_issued_for_cui_claimant_and_defendant_bilingual_caseProgression_allFinalOrdersIssued() {
 
         Map<String, Object> data = new HashMap<>();
@@ -2286,7 +2260,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
     void if_this_test_fails_needs_updating_with_your_changes() {
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(367));
+        assertThat(logic.getRules().size(), is(374));
     }
 
     @ParameterizedTest
@@ -3198,24 +3172,6 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
 
     @ParameterizedTest
     @CsvSource({
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, FAST_CLAIM,, false, true,,, Reschedule a Fast Track Hearing - HMC",
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, FAST_CLAIM,, true, false,,, Reschedule a Fast Track Hearing - HMC",
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, FAST_CLAIM,, false, false,,, Reschedule a Fast Track Hearing - HMC",
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, FAST_CLAIM, false, true,,, Reschedule a Fast Track Hearing - HMC",
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, FAST_CLAIM, true, false,,, Reschedule a Fast Track Hearing - HMC",
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, FAST_CLAIM, false, false,,, Reschedule a Fast Track Hearing - HMC",
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, SMALL_CLAIM,, false, true,,, Reschedule a Small Claims Hearing - HMC",
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, SMALL_CLAIM,, true, false,,, Reschedule a Small Claims Hearing - HMC",
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, SMALL_CLAIM,, false, false,,, Reschedule a Small Claims Hearing - HMC",
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, SMALL_CLAIM, false, true,,, Reschedule a Small Claims Hearing - HMC",
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, SMALL_CLAIM, true, false,,, Reschedule a Small Claims Hearing - HMC",
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, SMALL_CLAIM, false, false,,, Reschedule a Small Claims Hearing - HMC",
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, true, DISPOSAL,, Reschedule a Disposal Hearing - HMC",
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, true, false, DISPOSAL,, Reschedule a Disposal Hearing - HMC",
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, false, DISPOSAL,, Reschedule a Disposal Hearing - HMC",
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, true,, DISPOSAL_HEARING, Reschedule a Disposal Hearing - HMC",
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, true, false,, DISPOSAL_HEARING, Reschedule a Disposal Hearing - HMC",
-        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, false,, DISPOSAL_HEARING, Reschedule a Disposal Hearing - HMC",
         "HEARING_SCHEDULED_RETRIGGER, CASE_PROGRESSION, FAST_CLAIM,, false, true,,, Reschedule a Fast Track Hearing - HMC",
         "HEARING_SCHEDULED_RETRIGGER, CASE_PROGRESSION, FAST_CLAIM,, true, false,,, Reschedule a Fast Track Hearing - HMC",
         "HEARING_SCHEDULED_RETRIGGER, CASE_PROGRESSION, FAST_CLAIM,, false, false,,, Reschedule a Fast Track Hearing - HMC",
@@ -3235,7 +3191,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
         "HEARING_SCHEDULED_RETRIGGER, CASE_PROGRESSION,,, true, false,, DISPOSAL_HEARING, Reschedule a Disposal Hearing - HMC",
         "HEARING_SCHEDULED_RETRIGGER, CASE_PROGRESSION,,, false, false,, DISPOSAL_HEARING, Reschedule a Disposal Hearing - HMC"
     })
-    void given_input_should_return_correct_scheduleHmcHearingTask_lipEnabled(
+    void given_input_should_return_correct_scheduleHmcHearingTask_hearingScheduledRetrigger_lipEnabled(
         String eventId,
         String postEventState,
         String allocatedTrack,
@@ -3270,6 +3226,181 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
         assertThat(workTypeResultList.get(1).get("name"), is(expectedTaskName));
 
         assertThat(workTypeResultList.get(1).get("taskId"), is("ScheduleHMCHearing"));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, FAST_CLAIM,, true, true,,, Reschedule a Fast Track Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, FAST_CLAIM,, false, true,,, Reschedule a Fast Track Hearing, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, FAST_CLAIM,, false, false,,, Reschedule a Fast Track Hearing, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, FAST_CLAIM, true, true,,, Reschedule a Fast Track Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, FAST_CLAIM, false, true,,, Reschedule a Fast Track Hearing, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, FAST_CLAIM, false, false,,, Reschedule a Fast Track Hearing, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, SMALL_CLAIM,, true, true,,, Reschedule a Small Claims Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, SMALL_CLAIM,, false, true,,, Reschedule a Small Claims Hearing, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, SMALL_CLAIM,, false, false,,, Reschedule a Small Claims Hearing, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, SMALL_CLAIM, true, true,,, Reschedule a Small Claims Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, SMALL_CLAIM, false, true,,, Reschedule a Small Claims Hearing, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, SMALL_CLAIM, false, false,,, Reschedule a Small Claims Hearing, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, true, true, DISPOSAL,, Reschedule a Disposal Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, true, DISPOSAL,, Reschedule a Disposal Hearing, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, false, DISPOSAL,, Reschedule a Disposal Hearing, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, true, true,, DISPOSAL_HEARING, Reschedule a Disposal Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, true,, DISPOSAL_HEARING, Reschedule a Disposal Hearing, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, false,, DISPOSAL_HEARING, Reschedule a Disposal Hearing, SHOW",
+
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, FAST_CLAIM,, true, true,,, Reschedule a Fast Track Hearing - HMC, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, FAST_CLAIM,, false, true,,, Reschedule a Fast Track Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, FAST_CLAIM,, false, false,,, Reschedule a Fast Track Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, FAST_CLAIM, true, true,,, Reschedule a Fast Track Hearing - HMC, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, FAST_CLAIM, false, true,,, Reschedule a Fast Track Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, FAST_CLAIM, false, false,,, Reschedule a Fast Track Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, SMALL_CLAIM,, true, true,,, Reschedule a Small Claims Hearing - HMC, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, SMALL_CLAIM,, false, true,,, Reschedule a Small Claims Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, SMALL_CLAIM,, false, false,,, Reschedule a Small Claims Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, SMALL_CLAIM, true, true,,, Reschedule a Small Claims Hearing - HMC, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, SMALL_CLAIM, false, true,,, Reschedule a Small Claims Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, SMALL_CLAIM, false, false,,, Reschedule a Small Claims Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, true, true, DISPOSAL,, Reschedule a Disposal Hearing - HMC,",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, true, DISPOSAL,, Reschedule a Disposal Hearing,",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, false, DISPOSAL,, Reschedule a Disposal Hearing,",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, true, true,, DISPOSAL_HEARING, Reschedule a Disposal Hearing - HMC, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, true,, DISPOSAL_HEARING, Reschedule a Disposal Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, false,, DISPOSAL_HEARING, Reschedule a Disposal Hearing, "
+    })
+    void given_input_should_return_correct_rescheduleHmcHearingTask_generateDirectionsOrder_caseEventBatch2(
+        String eventId,
+        String postEventState,
+        String allocatedTrack,
+        String responseClaimTrack,
+        boolean applicant1Represented,
+        boolean respondent1Represented,
+        String orderType,
+        String caseManagementOrderSelection,
+        String expectedTaskName,
+        String furtherHearingRequired
+    ) {
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("featureToggleWA", "CE_B2");
+        addNonNullField(data, "applicant1Represented", applicant1Represented);
+        addNonNullField(data, "respondent1Represented", respondent1Represented);
+        addNonNullField(data, "allocatedTrack", allocatedTrack);
+        addNonNullField(data, "responseClaimTrack", responseClaimTrack);
+        addNonNullField(data, "orderType", orderType);
+        addNonNullField(data, "caseManagementOrderSelection", caseManagementOrderSelection);
+        addNonNullField(data, "finalOrderFurtherHearingToggle", furtherHearingRequired);
+
+        Map<String, Object> caseData = Map.of("Data", data);
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", eventId);
+        inputVariables.putValue("postEventState", postEventState);
+        inputVariables.putValue("additionalData", caseData);
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+        //This will be 3 until CE_B2 goes live a pre-existing tasks gets removed.
+        String taskId = applicant1Represented&& respondent1Represented ? "ScheduleHMCHearing" : "ScheduleAHearing";
+        if (nonNull(furtherHearingRequired)) {
+            assertThat(workTypeResultList.size(), is(3));
+            assertThat(workTypeResultList.get(0).get("name"), is("Order Made - Review case"));
+            assertThat(workTypeResultList.get(0).get("taskId"), is("reviewOrder"));
+            assertThat(workTypeResultList.get(1).get("name"), is(expectedTaskName));
+            assertThat(workTypeResultList.get(1).get("taskId"), is(taskId));
+            assertThat(workTypeResultList.get(2).get("name"), is(expectedTaskName));
+            assertThat(workTypeResultList.get(2).get("taskId"), is(taskId));
+        } else {
+            assertThat(workTypeResultList.size(), is(2));
+            assertThat(workTypeResultList.get(0).get("name"), is("Order Made - Review case"));
+            assertThat(workTypeResultList.get(0).get("taskId"), is("reviewOrder"));
+            assertThat(workTypeResultList.get(1).get("name"), is(expectedTaskName));
+            assertThat(workTypeResultList.get(1).get("taskId"), is(taskId));
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, FAST_CLAIM,, false, true,,, Reschedule a Fast Track Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, FAST_CLAIM,, true, false,,, Reschedule a Fast Track Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, FAST_CLAIM,, false, false,,, Reschedule a Fast Track Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, FAST_CLAIM, false, true,,, Reschedule a Fast Track Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, FAST_CLAIM, true, false,,, Reschedule a Fast Track Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, FAST_CLAIM, false, false,,, Reschedule a Fast Track Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, SMALL_CLAIM,, false, true,,, Reschedule a Small Claims Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, SMALL_CLAIM,, true, false,,, Reschedule a Small Claims Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, SMALL_CLAIM,, false, false,,, Reschedule a Small Claims Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, SMALL_CLAIM, false, true,,, Reschedule a Small Claims Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, SMALL_CLAIM, true, false,,, Reschedule a Small Claims Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, SMALL_CLAIM, false, false,,, Reschedule a Small Claims Hearing - HMC, SHOW",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, true, DISPOSAL,, Reschedule a Disposal Hearing - HMC, true",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, true, false, DISPOSAL,, Reschedule a Disposal Hearing - HMC, true",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, false, DISPOSAL,, Reschedule a Disposal Hearing - HMC, true",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, true,, DISPOSAL_HEARING, Reschedule a Disposal Hearing - HMC, true",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, true, false,, DISPOSAL_HEARING, Reschedule a Disposal Hearing - HMC, true",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, false,, DISPOSAL_HEARING, Reschedule a Disposal Hearing - HMC, true",
+
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, FAST_CLAIM,, false, true,,, Reschedule a Fast Track Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, FAST_CLAIM,, true, false,,, Reschedule a Fast Track Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, FAST_CLAIM,, false, false,,, Reschedule a Fast Track Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, FAST_CLAIM, false, true,,, Reschedule a Fast Track Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, FAST_CLAIM, true, false,,, Reschedule a Fast Track Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, FAST_CLAIM, false, false,,, Reschedule a Fast Track Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, SMALL_CLAIM,, false, true,,, Reschedule a Small Claims Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, SMALL_CLAIM,, true, false,,, Reschedule a Small Claims Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION, SMALL_CLAIM,, false, false,,, Reschedule a Small Claims Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, SMALL_CLAIM, false, true,,, Reschedule a Small Claims Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, SMALL_CLAIM, true, false,,, Reschedule a Small Claims Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,, SMALL_CLAIM, false, false,,, Reschedule a Small Claims Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, true, DISPOSAL,, Reschedule a Disposal Hearing,",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, true, false, DISPOSAL,, Reschedule a Disposal Hearing,",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, false, DISPOSAL,, Reschedule a Disposal Hearing,",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, true,, DISPOSAL_HEARING, Reschedule a Disposal Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, true, false,, DISPOSAL_HEARING, Reschedule a Disposal Hearing, ",
+        "GENERATE_DIRECTIONS_ORDER, CASE_PROGRESSION,,, false, false,, DISPOSAL_HEARING, Reschedule a Disposal Hearing, "
+    })
+    void given_input_should_return_correct_rescheduleHmcHearingTask_generateDirectionsOrder_lipEnabled(
+        String eventId,
+        String postEventState,
+        String allocatedTrack,
+        String responseClaimTrack,
+        boolean applicant1Represented,
+        boolean respondent1Represented,
+        String orderType,
+        String caseManagementOrderSelection,
+        String expectedTaskName,
+        String furtherHearingRequired
+    ) {
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("featureToggleWA", "HMC_LIP");
+        addNonNullField(data, "applicant1Represented", applicant1Represented);
+        addNonNullField(data, "respondent1Represented", respondent1Represented);
+        addNonNullField(data, "allocatedTrack", allocatedTrack);
+        addNonNullField(data, "responseClaimTrack", responseClaimTrack);
+        addNonNullField(data, "orderType", orderType);
+        addNonNullField(data, "caseManagementOrderSelection", caseManagementOrderSelection);
+        addNonNullField(data, "finalOrderFurtherHearingToggle", furtherHearingRequired);
+
+        Map<String, Object> caseData = Map.of("Data", data);
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("eventId", eventId);
+        inputVariables.putValue("postEventState", postEventState);
+        inputVariables.putValue("additionalData", caseData);
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+        //This will be 2 until Hmc Lip goes live a pre-existing tasks gets removed.
+        if (nonNull(furtherHearingRequired)) {
+            assertThat(workTypeResultList.size(), is(2));
+            assertThat(workTypeResultList.get(1).get("name"), is(expectedTaskName));
+            assertThat(workTypeResultList.get(1).get("taskId"), is("ScheduleHMCHearing"));
+        } else {
+            assertThat(workTypeResultList.size(), is(1));
+            assertThat(workTypeResultList.get(0).get("name"), is(expectedTaskName));
+            assertThat(workTypeResultList.get(0).get("taskId"), is("ScheduleAHearing"));
+        }
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-16552


### Change description ###
Create rules to replace GENERATE_DIRECTIONS_ORDERS rules where CASE_PROGRESSION state triggers reschedule task.
Instead generate Reschedule when Further Hearing Toggle was ticked in GENERATE_DIRECTIONS_ORDER
![image](https://github.com/user-attachments/assets/236a470e-d2db-477e-9824-2f0adb99c3fc)
![image](https://github.com/user-attachments/assets/aeada0a1-6e50-4fa9-9727-75b716f560d8)
![image](https://github.com/user-attachments/assets/b5d3f61d-a011-407f-8148-0f6dc76bd79f)
![image](https://github.com/user-attachments/assets/718c58d8-9221-47e1-9bf0-2cce80e8f3bc)
![image](https://github.com/user-attachments/assets/6c57682c-940b-44a5-b3bf-4bcf835649e9)
![image](https://github.com/user-attachments/assets/38e6fe16-d545-4fd3-93b6-cc0865de6796)



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
