### PR TITLE
CIV-16642 - re-added work type to configuration

### DIFF
--- a/src/main/resources/wa-task-configuration-civil-civil.dmn
+++ b/src/main/resources/wa-task-configuration-civil-civil.dmn
@@ -3096,6 +3096,26 @@ else ""</text>
           <text>true</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_1lv8a8u">
+        <inputEntry id="UnaryTests_1ms1f9r">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0y0u6th">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1gmk95y">
+          <text>"confirmOrderReviewUnlessOrder", "confirmOrderReviewFreeTrial", "confirmOrderReviewGeneralOrder", "confirmOrderReviewReserveJudgement", "confirmOrderReviewOther", "confirmOrderReviewDismissCase", "confirmOrderReviewManageStay", "confirmOrderReviewStayCase"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0xiq7m6">
+          <text>"workType"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0clod4a">
+          <text>"routine_work"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0vuf1a6">
+          <text>false</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_1kv3uyc">
         <inputEntry id="UnaryTests_10hkuyl">
           <text></text>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
@@ -36,7 +36,7 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
 
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(169));
+        assertThat(logic.getRules().size(), is(170));
     }
 
     @SuppressWarnings("checkstyle:indentation")


### PR DESCRIPTION
### Change description ###
Re-add rule for our work_type for confirm order, which was overridden


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
