### PR TITLE
CIV-16752 - switch SetAside permission to admin

### DIFF
--- a/src/main/resources/wa-task-configuration-civil-civil.dmn
+++ b/src/main/resources/wa-task-configuration-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.5.1">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.30.0">
   <decision id="wa-task-configuration-civil-civil" name="Civil Task configuration DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_14cx0791" hitPolicy="COLLECT">
       <input id="InputClause_1gxyo7fa" label="CCD Case Data" camunda:inputVariable="caseData">
@@ -2107,7 +2107,7 @@ else ""</text>
           <text>"roleCategory"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0tez8ym">
-          <text>"CTSC"</text>
+          <text>"ADMIN"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0kwih8d">
           <text>true</text>

--- a/src/main/resources/wa-task-permissions-civil-civil.dmn
+++ b/src/main/resources/wa-task-permissions-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.5.1">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.30.0">
   <decision id="wa-task-permissions-civil-civil" name="Civil Permissions DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_1pr5oica" hitPolicy="RULE ORDER">
       <input id="InputClause_12crj6ea" label="Task Type" biodi:width="207" camunda:inputVariable="taskType">
@@ -1436,13 +1436,13 @@ else
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_19ew4hg">
-          <text>"ctsc-team-leader"</text>
+          <text>"hearing-centre-admin"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0lq9ho3">
           <text>"Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0qzpnhr">
-          <text>"CTSC"</text>
+          <text>"ADMIN"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1liqtbq">
           <text></text>
@@ -1469,13 +1469,13 @@ else
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1j30sib">
-          <text>"ctsc"</text>
+          <text>"hearing-centre-team-leader"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_02x1vsv">
           <text>"Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1abufc6">
-          <text>"CTSC"</text>
+          <text>"ADMIN"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0s3n6fa">
           <text></text>
@@ -1484,6 +1484,39 @@ else
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_030ept6">
+          <text>false</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1jswf4d">
+        <description>Caseworker task permissions</description>
+        <inputEntry id="UnaryTests_1w47sek">
+          <text>"JudgmentOnlineSetAsideTakeCaseOffline"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0miu6f2">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11mbr5u">
+          <text>"JO"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0l0hkr0">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0on663x">
+          <text>"hearing-centre-admin-team-leader"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0v3glki">
+          <text>"Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1jyyixr">
+          <text>"ADMIN"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_03yb93t">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1o6dei1">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1gfbl89">
           <text>false</text>
         </outputEntry>
       </rule>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaConfigurationTest.java
@@ -1717,7 +1717,7 @@ class CamundaTaskWaConfigurationTest extends DmnDecisionTableBaseUnitTest {
             .collect(Collectors.toList());
         assertTrue(roleCategoryResultList.contains(Map.of(
             "name", "roleCategory",
-            "value", "CTSC",
+            "value", "ADMIN",
             "canReconfigure", "true"
         )));
         assertTrue(dmnDecisionTableResult.getResultList().contains(Map.of(

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaPermissionTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaPermissionTest.java
@@ -1077,15 +1077,21 @@ class CamundaTaskWaPermissionTest extends DmnDecisionTableBaseUnitTest {
                 "value", "Read,Manage,Cancel,Unassign,Assign"
             ),
             Map.of(
-                "name", "ctsc-team-leader",
+                "name", "hearing-centre-admin",
                 "value", "Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn",
-                "roleCategory", "CTSC",
+                "roleCategory", "ADMIN",
                 "autoAssignable", false
             ),
             Map.of(
-                "name", "ctsc",
+                "name", "hearing-centre-team-leader",
                 "value", "Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn",
-                "roleCategory", "CTSC",
+                "roleCategory", "ADMIN",
+                "autoAssignable", false
+            ),
+            Map.of(
+                "name", "hearing-centre-admin-team-leader",
+                "value", "Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn",
+                "roleCategory", "ADMIN",
                 "autoAssignable", false
             )
         )));


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-16752


### Change description ###
Switch permissions for task from CTSC to ADMIN

Configuration - feature toggle not showing here, but I did not remove it
![image](https://github.com/user-attachments/assets/d4b6cb0a-1fa3-4602-8e70-f4f5d8048a2e)

Permissions
![image](https://github.com/user-attachments/assets/eceb62c1-799c-4fed-a148-6b3fcdb1e06e)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
