### PR TITLE
CIV-16938 Change PostEventState for SETTLE_CLAIM_MARKED _PAID IN_FILL

### DIFF
--- a/src/main/resources/wa-task-initiation-civil-civil.dmn
+++ b/src/main/resources/wa-task-initiation-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.30.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.27.0">
   <decision id="wa-task-initiation-civil-civil" name="Civil Task initiation DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_0jtevuc" hitPolicy="COLLECT" biodi:annotationsWidth="400">
       <input id="Input_1" label="Event Id" biodi:width="259" camunda:inputVariable="eventId">
@@ -58304,7 +58304,7 @@ else
           <text>"SETTLE_CLAIM_MARK_PAID_FULL"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0ncwxqw">
-          <text>"CLOSED"</text>
+          <text>"CASE_STAYED"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1b8zv0h">
           <text>"SD"</text>
@@ -58498,7 +58498,7 @@ else
           <text>"SETTLE_CLAIM_MARK_PAID_FULL"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1u5affv">
-          <text>"CLOSED"</text>
+          <text>"CASE_STAYED"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0sb8990">
           <text>"SD"</text>
@@ -66262,7 +66262,7 @@ else
           <text>"SETTLE_CLAIM_MARK_PAID_FULL"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_16dufb6">
-          <text>"CLOSED"</text>
+          <text>"CASE_STAYED"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0my4a91">
           <text></text>
@@ -66651,7 +66651,7 @@ else
           <text>"SETTLE_CLAIM_MARK_PAID_FULL"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1juhr6m">
-          <text>"CLOSED"</text>
+          <text>"CASE_STAYED"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_12kmaax">
           <text>"SD"</text>
@@ -71718,7 +71718,7 @@ else
           <text>"SETTLE_CLAIM_MARK_PAID_FULL"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1g7j5d8">
-          <text>"CLOSED"</text>
+          <text>"CASE_STAYED"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0i0q8qz">
           <text>"HMC_LIP"</text>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
@@ -1250,13 +1250,14 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
         data.put("featureToggleWA", "SD");
         data.put("applicant1Represented", false);
         data.put("hearingDate", "22-12-2024");
+        data.put("preStayState", "AWAITING_RESPONDENT_ACKNOWLEDGEMENT");
         Map<String, Object> caseData = new HashMap<>();
         caseData.put("Data", data);
 
         VariableMap inputVariables = new VariableMapImpl();
         inputVariables.putValue("eventId", "SETTLE_CLAIM_MARK_PAID_FULL");
         inputVariables.putValue("additionalData", caseData);
-        inputVariables.putValue("postEventState", "CLOSED");
+        inputVariables.putValue("postEventState", "CASE_STAYED");
         DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
 
         List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
@@ -2480,7 +2481,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
 
     @ParameterizedTest
     @CsvSource({
-        "SETTLE_CLAIM_MARK_PAID_FULL, CLOSED, 22-12-2024",
+        "SETTLE_CLAIM_MARK_PAID_FULL, CASE_STAYED, 22-12-2024",
         "SETTLE_CLAIM, CASE_SETTLED, 22-12-2024"
     })
     void given_input_should_return_correct_removeHmcHearingTask_noLipSmallClaimUnspec(
@@ -2493,6 +2494,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
         data.put("featureToggleWA", "SD");
         data.put("allocatedTrack", "SMALL_CLAIM");
         addNonNullField(data, "hearingDate", hearingDate);
+        addNonNullField(data,"preStayState", "AWAITING_RESPONDENT_ACKNOWLEDGEMENT");
 
         Map<String, Object> caseData = Map.of("Data", data);
         VariableMap inputVariables = new VariableMapImpl();
@@ -2511,7 +2513,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
 
     @ParameterizedTest
     @CsvSource({
-        "SETTLE_CLAIM_MARK_PAID_FULL, CLOSED, 22-12-2024, 1",
+        "SETTLE_CLAIM_MARK_PAID_FULL, CASE_STAYED, 22-12-2024, 1",
         "SETTLE_CLAIM, CASE_SETTLED, 22-12-2024, 1"
     })
     void given_input_should_return_correct_removeHmcHearingTask_noLipFastClaimUnspec(
@@ -2525,6 +2527,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
         data.put("featureToggleWA", "SD");
         data.put("allocatedTrack", "FAST_CLAIM");
         addNonNullField(data, "hearingDate", hearingDate);
+        addNonNullField(data,"preStayState", "AWAITING_RESPONDENT_ACKNOWLEDGEMENT");
 
         Map<String, Object> caseData = Map.of("Data", data);
         VariableMap inputVariables = new VariableMapImpl();
@@ -2543,7 +2546,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
 
     @ParameterizedTest
     @CsvSource({
-        "SETTLE_CLAIM_MARK_PAID_FULL, CLOSED, 22-12-2024, 1",
+        "SETTLE_CLAIM_MARK_PAID_FULL, CASE_STAYED, 22-12-2024, 1",
         "SETTLE_CLAIM, CASE_SETTLED, 22-12-2024, 1"
     })
     void given_input_should_return_correct_removeHmcHearingTask_noLipSmallClaimSpec(
@@ -2557,6 +2560,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
         data.put("featureToggleWA", "SD");
         data.put("responseClaimTrack", "SMALL_CLAIM");
         addNonNullField(data, "hearingDate", hearingDate);
+        addNonNullField(data,"preStayState", "AWAITING_RESPONDENT_ACKNOWLEDGEMENT");
 
         Map<String, Object> caseData = Map.of("Data", data);
         VariableMap inputVariables = new VariableMapImpl();
@@ -2575,7 +2579,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
 
     @ParameterizedTest
     @CsvSource({
-        "SETTLE_CLAIM_MARK_PAID_FULL, CLOSED, 22-12-2024, 1",
+        "SETTLE_CLAIM_MARK_PAID_FULL, CASE_STAYED, 22-12-2024, 1",
         "SETTLE_CLAIM, CASE_SETTLED, 22-12-2024, 1"
     })
     void given_input_should_return_correct_removeHmcHearingTask_noLipFastClaimSpec(
@@ -2589,6 +2593,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
         data.put("featureToggleWA", "SD");
         data.put("responseClaimTrack", "FAST_CLAIM");
         addNonNullField(data, "hearingDate", hearingDate);
+        addNonNullField(data,"preStayState", "AWAITING_RESPONDENT_ACKNOWLEDGEMENT");
 
         Map<String, Object> caseData = Map.of("Data", data);
         VariableMap inputVariables = new VariableMapImpl();
@@ -3053,9 +3058,9 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
 
     @ParameterizedTest
     @CsvSource({
-        "SETTLE_CLAIM_MARK_PAID_FULL, CLOSED, false, true, 22-12-2024",
-        "SETTLE_CLAIM_MARK_PAID_FULL, CLOSED, true, false, 22-12-2024",
-        "SETTLE_CLAIM_MARK_PAID_FULL, CLOSED, false, false, 22-12-2024",
+        "SETTLE_CLAIM_MARK_PAID_FULL, CASE_STAYED, false, true, 22-12-2024",
+        "SETTLE_CLAIM_MARK_PAID_FULL, CASE_STAYED, true, false, 22-12-2024",
+        "SETTLE_CLAIM_MARK_PAID_FULL, CASE_STAYED, false, false, 22-12-2024",
         "SETTLE_CLAIM, CASE_SETTLED, false, true, 22-12-2024",
         "SETTLE_CLAIM, CASE_SETTLED, true, false, 22-12-2024",
         "SETTLE_CLAIM, CASE_SETTLED, false, false, 22-12-2024",
@@ -3073,6 +3078,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
         addNonNullField(data, "hearingDate", hearingDate);
         addNonNullField(data, "applicant1Represented", applicant1Represented);
         addNonNullField(data, "respondent1Represented", respondent1Represented);
+        addNonNullField(data,"preStayState", "AWAITING_RESPONDENT_ACKNOWLEDGEMENT");
         Map<String, Object> caseData = Map.of("Data", data);
         VariableMap inputVariables = new VariableMapImpl();
         inputVariables.putValue("eventId", eventId);
@@ -3563,9 +3569,9 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
 
     @ParameterizedTest
     @CsvSource({
-        "SETTLE_CLAIM_MARK_PAID_FULL, CLOSED, false, true, 22-12-2024",
-        "SETTLE_CLAIM_MARK_PAID_FULL, CLOSED, true, false, 22-12-2024",
-        "SETTLE_CLAIM_MARK_PAID_FULL, CLOSED, false, false, 22-12-2024",
+        "SETTLE_CLAIM_MARK_PAID_FULL, CASE_STAYED, false, true, 22-12-2024",
+        "SETTLE_CLAIM_MARK_PAID_FULL, CASE_STAYED, true, false, 22-12-2024",
+        "SETTLE_CLAIM_MARK_PAID_FULL, CASE_STAYED, false, false, 22-12-2024",
         "LIP_CLAIM_SETTLED, CASE_SETTLED, false, true, 22-12-2024",
         "SETTLE_CLAIM, CASE_SETTLED, true, false, 22-12-2024",
         "LIP_CLAIM_SETTLED, CASE_SETTLED, false, false, 22-12-2024"
@@ -3583,6 +3589,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
         addNonNullField(data, "hearingDate", hearingDate);
         addNonNullField(data, "applicant1Represented", applicant1Represented);
         addNonNullField(data, "respondent1Represented", respondent1Represented);
+        addNonNullField(data, "preStayState", "AWAITING_RESPONDENT_ACKNOWLEDGEMENT");
         Map<String, Object> caseData = Map.of("Data", data);
         VariableMap inputVariables = new VariableMapImpl();
         inputVariables.putValue("eventId", eventId);
@@ -3639,7 +3646,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
         "HEARING_FEE_UNPAID, CASE_DISMISSED, MULTI_CLAIM, , , removeHearing",
         "VALIDATE_DISCONTINUE_CLAIM_CLAIMANT, , MULTI_CLAIM, , validateDiscontinuance, removeHearing",
         "DISCONTINUE_CLAIM_CLAIMANT, , MULTI_CLAIM, discontinuanceType, , removeHearing",
-        "SETTLE_CLAIM_MARK_PAID_FULL, CLOSED, MULTI_CLAIM, , , removeHearing",
+        "SETTLE_CLAIM_MARK_PAID_FULL, CASE_STAYED, MULTI_CLAIM, , , removeHearing",
         "SETTLE_CLAIM, CASE_SETTLED, MULTI_CLAIM, , , removeHearing",
     })
     void given_input_should_return_remove_hearing_minti_unspec(String eventName, String postState, String multiOrIntermediate,
@@ -3647,6 +3654,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
         Map<String, Object> data = new HashMap<>();
         data.put("hearingDate", "22-12-2024");
         data.put("allocatedTrack", multiOrIntermediate);
+        data.put("preStayState", "AWAITING_RESPONDENT_ACKNOWLEDGEMENT");
 
         if (nonNull(discontinuanceType)) {
             data.put("isDiscontinuingAgainstBothDefendants", "YES");


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-16938

### Change description ###
Change PostEventState for SETTLE_CLAIM_MARKED _PAID IN_FILL
<img width="381" alt="image" src="https://github.com/user-attachments/assets/5594cf92-2f15-4073-bccc-73c4191169b9" />
<img width="332" alt="image" src="https://github.com/user-attachments/assets/52d11150-e551-4d07-832b-736614dc1e5f" />
<img width="397" alt="image" src="https://github.com/user-attachments/assets/afa849d6-8d86-43cd-9d92-77210e99bcf0" />


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
