### PR TITLE
CIV-17003 Remove Old QM Config

### DIFF
--- a/src/main/resources/wa-task-permissions-civil-civil.dmn
+++ b/src/main/resources/wa-task-permissions-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.30.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-permissions-civil-civil" name="Civil Permissions DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_1pr5oica" hitPolicy="RULE ORDER">
       <input id="InputClause_12crj6ea" label="Task Type" biodi:width="207" camunda:inputVariable="taskType">
@@ -566,7 +566,7 @@ else
       <rule id="DecisionRule_1r6nyc0">
         <description>Transfer online case task for CTSC</description>
         <inputEntry id="UnaryTests_19alxwb">
-          <text>"transferOnlineCase","queryManagementRespondToQuery"</text>
+          <text>"transferOnlineCase"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0kqflsg">
           <text></text>
@@ -599,7 +599,7 @@ else
       <rule id="DecisionRule_0v4teg1">
         <description>Transfer online case task for CCMCC/CCBC</description>
         <inputEntry id="UnaryTests_12f81q7">
-          <text>"transferOnlineCase","queryManagementRespondToQuery"</text>
+          <text>"transferOnlineCase"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1rxhm0z">
           <text></text>
@@ -632,7 +632,7 @@ else
       <rule id="DecisionRule_08wpjkw">
         <description>Listing Officer task permissions</description>
         <inputEntry id="UnaryTests_0y6qy86">
-          <text>"transferOnlineCase","OnlineCaseTransferReceived","queryManagementRespondToQuery"</text>
+          <text>"transferOnlineCase","OnlineCaseTransferReceived"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1e1wc9v">
           <text></text>
@@ -665,7 +665,7 @@ else
       <rule id="DecisionRule_0h3a57s">
         <description>Access request for Listing Officers</description>
         <inputEntry id="UnaryTests_03ib30r">
-          <text>"transferOnlineCase","queryManagementRespondToQuery"</text>
+          <text>"transferOnlineCase"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_129az21">
           <text></text>
@@ -698,7 +698,7 @@ else
       <rule id="DecisionRule_0fewowx">
         <description>Access request for CTSC</description>
         <inputEntry id="UnaryTests_10qaxdd">
-          <text>"transferOnlineCase","queryManagementRespondToQuery"</text>
+          <text>"transferOnlineCase"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0l7y38w">
           <text></text>
@@ -731,7 +731,7 @@ else
       <rule id="DecisionRule_13821n4">
         <description>Access request for CCMCC/CCBC</description>
         <inputEntry id="UnaryTests_0p4exql">
-          <text>"transferOnlineCase","queryManagementRespondToQuery"</text>
+          <text>"transferOnlineCase"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1fifjq3">
           <text></text>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-17003

### Change description ###
Removed references to old query management task in permissions config.

<img width="1776" alt="Screenshot 2025-04-09 at 11 05 30" src="https://github.com/user-attachments/assets/09724d73-1188-4793-8cbf-c8a51378897b" />


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
