### PR TITLE
CIV-16915 - Respond to application - Changes to WA task

### DIFF
--- a/src/main/resources/wa-task-completion-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-completion-civil-generalapplication.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-completion-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.9.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-completion-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.33.1">
   <decision id="wa-task-completion-civil-generalapplication" name="Civil GA Task completion DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_01re27m" hitPolicy="COLLECT">
       <input id="eventId" label="Event ID" biodi:width="226">
@@ -169,6 +169,18 @@
           <text>"applicationDocumentsWelshRequestAppSum"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0j38yvc">
+          <text>"Auto"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1k8glsn">
+        <description>Event that is completed by the user in ExUI. Values can be listed as comma separated</description>
+        <inputEntry id="UnaryTests_1kt84wv">
+          <text>"UPLOAD_TRANSLATED_DOCUMENT"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1p26jn0">
+          <text>"applicationDocumentsWelshRequestAppSumResponded"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1eds0jp">
           <text>"Auto"</text>
         </outputEntry>
       </rule>

--- a/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
@@ -14597,7 +14597,7 @@ else
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_02252qu">
-          <text>true</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0n0ph5w">
           <text></text>
@@ -14609,10 +14609,10 @@ else
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_01y8hf7">
-          <text>true</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_16bt2el">
-          <text>true</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1x2octr">
           <text></text>

--- a/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
+++ b/src/main/resources/wa-task-initiation-civil-generalapplication.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="Definitions_0wgjriw" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.14.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="Definitions_0wgjriw" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.33.1">
   <decision id="wa-task-initiation-civil-generalapplication" name="Civil GA Task initiation DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_141h4ty" hitPolicy="COLLECT" biodi:annotationsWidth="404">
       <input id="Input_1" label="Event Id" camunda:inputVariable="eventId">
@@ -14558,10 +14558,10 @@ else
       </rule>
       <rule id="DecisionRule_0pqvzim">
         <inputEntry id="UnaryTests_156t6de">
-          <text>"END_BUSINESS_PROCESS_GASPEC"</text>
+          <text>"GENERATE_DRAFT_DOCUMENT"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_18ty8uk">
-          <text>"APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION"</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0kq71ye">
           <text></text>
@@ -14621,7 +14621,7 @@ else
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1o10bbj">
-          <text></text>
+          <text>"RESPOND_TO_APPLICATION_SUMMARY_DOC"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0xdi3is">
           <text>"applicationDocumentsWelshRequestAppSumResponded"</text>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmnga/CamundaGaSubmissionTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmnga/CamundaGaSubmissionTaskWaInitiationTest.java
@@ -4837,14 +4837,11 @@ public class CamundaGaSubmissionTaskWaInitiationTest extends DmnDecisionTableBas
     @Test
     void given_input_should_return_applicationDocumentsWelshRequest_ifRespondentResponds() {
         Map<String, Object> data = new HashMap<>();
-        data.put("isGaApplicantLip", true);
-        data.put("applicantBilingualLanguagePreference", true);
-        data.put("respondentsResponses", new Object());
+        data.put("preTranslationGaDocumentType", "RESPOND_TO_APPLICATION_SUMMARY_DOC");
         Map<String, Object> caseData = new HashMap<>();
         caseData.put("Data", data);
         VariableMap inputVariables = new VariableMapImpl();
-        inputVariables.putValue("eventId", "END_BUSINESS_PROCESS_GASPEC");
-        inputVariables.putValue("postEventState", "APPLICATION_SUBMITTED_AWAITING_JUDICIAL_DECISION");
+        inputVariables.putValue("eventId", "GENERATE_DRAFT_DOCUMENT");
         inputVariables.putValue("additionalData", caseData);
         DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
 

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmnga/CamundaGaTaskCompletion.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmnga/CamundaGaTaskCompletion.java
@@ -155,7 +155,7 @@ public class CamundaGaTaskCompletion extends DmnDecisionTableBaseUnitTest {
 
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(26));
+        assertThat(logic.getRules().size(), is(27));
 
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-16915


### Change description ###
Refactored the existing WA task to ensure that an upload translated document task is generated when a respondent replies and the claim involves a bilingual party.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
