### PR TITLE
CIV-17353 Fast track SDO task not triggered when defendant is Welsh

### DIFF
--- a/src/main/resources/wa-task-initiation-civil-civil.dmn
+++ b/src/main/resources/wa-task-initiation-civil-civil.dmn
@@ -24528,7 +24528,7 @@ else
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ehgey5">
-          <text>&gt;10000</text>
+          <text>10000</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0xxnvd9">
           <text></text>
@@ -24922,7 +24922,7 @@ else
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0b2hut0">
-          <text>&gt;10000</text>
+          <text>10000</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1x8a4hc">
           <text></text>

--- a/src/main/resources/wa-task-initiation-civil-civil.dmn
+++ b/src/main/resources/wa-task-initiation-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.28.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.5.1">
   <decision id="wa-task-initiation-civil-civil" name="Civil Task initiation DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_0jtevuc" hitPolicy="COLLECT" biodi:annotationsWidth="400">
       <input id="Input_1" label="Event Id" biodi:width="259" camunda:inputVariable="eventId">
@@ -24528,7 +24528,7 @@ else
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1ehgey5">
-          <text>10000</text>
+          <text>&gt;10000</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0xxnvd9">
           <text></text>
@@ -24922,7 +24922,7 @@ else
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0b2hut0">
-          <text>10000</text>
+          <text>&gt;10000</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1x8a4hc">
           <text></text>
@@ -25099,6 +25099,203 @@ else
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_155prng">
+          <text>"standardDirectionsOrder"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1dsmj7i">
+        <inputEntry id="UnaryTests_1bv9nyo">
+          <text>"UPDATE_CLAIM_STATE_AFTER_DOC_UPLOADED"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ydvdqo">
+          <text>"JUDICIAL_REFERRAL"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1xy7f0s">
+          <text>"CUI_WELSH"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1nj3xfw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0nt4q03">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1tjxmfu">
+          <text>&gt;10000</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12gn57w">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_08oxixd">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1tzu6kb">
+          <text>"FAST_CLAIM"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1v60618">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qfmwgc">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tvuk3e">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0jpec15">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fryr0j">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1l6nztw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1suf3s8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1juvybg">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0z6cp6c">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kfaurt">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1cs5dg3">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0atcvcg">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10nl7yz">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0mjlg19">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_07cwlea">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hs5u34">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0tewxfu">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11o2ldd">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0qsvb83">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1waj7b4">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1u2n91m">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0zniplx">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1kxefah">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_17omym9">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1616iyb">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0bty8fk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0n4fju7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fbiy82">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lg5eez">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0kzg76e">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1d9hqzp">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1y0vz0t">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11qat94">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_11n5igz">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0c5i9hn">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0u7zyrz">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1fz2h6w">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15szzdf">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01vjzyz">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uyfbu6">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0c9zv6p">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0sr4vi7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wuvrw8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12a3767">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1xzfmb8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1rnlraz">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1koq2c8">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_19twy1m">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1doq7vw">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1aq24xz">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0iga365">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1q57729">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0wx2x18">
+          <text>"FastTrackDirections"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0nmed5r">
+          <text>"Fast Track Directions"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0g5r5ln">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_06g7cly">
           <text>"standardDirectionsOrder"</text>
         </outputEntry>
       </rule>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
@@ -2296,7 +2296,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
     void if_this_test_fails_needs_updating_with_your_changes() {
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(270));
+        assertThat(logic.getRules().size(), is(271));
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaInitiationTest.java
@@ -2268,7 +2268,7 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
     void if_this_test_fails_needs_updating_with_your_changes() {
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(269));
+        assertThat(logic.getRules().size(), is(270));
     }
 
     @ParameterizedTest
@@ -4224,5 +4224,28 @@ class CamundaTaskWaInitiationTest extends DmnDecisionTableBaseUnitTest {
         assertThat(workTypeResultList.size(), is(1));
         assertThat(workTypeResultList.get(0).get("name"), is("Upload Translated Defendant Sealed Claim Form"));
         assertThat(workTypeResultList.get(0).get("taskId"), is("uploadTranslatedOrderDocument"));
+    }
+
+    @Test
+    void shouldCreateWaTaskForFastTrackDirectionsOnceAfterTranslatedDocUploaded() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("featureToggleWA", "CUI_WELSH");
+        data.put("totalClaimAmount", "12000");
+        data.put("responseClaimTrack", "FAST_CLAIM");
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("Data", data);
+        VariableMap inputVariables = new VariableMapImpl();
+
+        inputVariables.putValue("eventId", "UPDATE_CLAIM_STATE_AFTER_DOC_UPLOADED");
+        inputVariables.putValue("postEventState", "JUDICIAL_REFERRAL");
+
+        inputVariables.putValue("additionalData", caseData);
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList();
+        assertThat(workTypeResultList.size(), is(1));
+        assertThat(workTypeResultList.get(0).get("name"), is("Fast Track Directions"));
+        assertThat(workTypeResultList.get(0).get("taskId"), is("FastTrackDirections"));
     }
 }


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-17353

### Change description ###

Once the WLU uploads the translated claimant DQ document (for a fast track claim) and submits this, the state then updates to Judicial Referral. A WA task should be triggered for a Judge to draw the fast track SDO. Currently the SDO WA task is not being triggered to the Judge where the claimant is English and Defendant is Welsh - this is because the DMNs only consider the claimant's language and not the defendant's language. In addition the DMN only checks for the existing bilingual flag for the claimant (rather than Welsh or Welsh + English). 

<img width="942" alt="image" src="https://github.com/user-attachments/assets/24f8e6d7-9005-4774-9c86-0a83388cba0a" />


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
