### PR TITLE
CIV-17685 DDJ access to allocateIntermediateTrack tasks

### DIFF
--- a/src/main/resources/wa-task-permissions-civil-civil.dmn
+++ b/src/main/resources/wa-task-permissions-civil-civil.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.14.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-permissions-civil-civil" name="Civil Permissions DMN" camunda:historyTimeToLive="P90D">
     <decisionTable id="DecisionTable_1pr5oica" hitPolicy="RULE ORDER">
       <input id="InputClause_12crj6ea" label="Task Type" biodi:width="207" camunda:inputVariable="taskType">
@@ -2543,10 +2543,43 @@ else
           <text>false</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_15wuojc">
+        <description>Judge task permissions</description>
+        <inputEntry id="UnaryTests_0grabs7">
+          <text>"allocateMultiTrack","allocateIntermediateTrack"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0lztg0t">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uy0mrw">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_11z633o">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_01bm3nk">
+          <text>"district-judge"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1fxvtmt">
+          <text>"Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1snrrrz">
+          <text>"JUDICIAL"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0xyxni6">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1wxeu2w">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1rukhw9">
+          <text>false</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_1keaeg0">
         <description>Judge task permissions</description>
         <inputEntry id="UnaryTests_1x8hki2">
-          <text>"allocateMultiTrack","allocateIntermediateTrack"</text>
+          <text>"allocateIntermediateTrack"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0niwxzm">
           <text></text>
@@ -2558,7 +2591,7 @@ else
           <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0uiuoe1">
-          <text>"district-judge"</text>
+          <text>"deputy-district-judge"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_106qv49">
           <text>"Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn"</text>

--- a/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaPermissionTest.java
+++ b/src/test/java/uk/gov/hmcts/civil/taskconfiguration/dmn/CamundaTaskWaPermissionTest.java
@@ -1426,14 +1426,10 @@ class CamundaTaskWaPermissionTest extends DmnDecisionTableBaseUnitTest {
         )));
     }
 
-    @ParameterizedTest
-    @CsvSource(value = {
-        "allocateMultiTrack",
-        "allocateIntermediateTrack"
-    })
-    void given_allocateMultiTrack_or_allocateIntermediateTrack_taskType_when_evaluate_dmn_then_it_returns_expected_rule(String taskName) {
+    @Test
+    void given_allocateMultiTrack_taskType_when_evaluate_dmn_then_it_returns_expected_rule() {
         VariableMap inputVariables = new VariableMapImpl();
-        inputVariables.putValue("taskAttributes", Map.of("taskType", taskName));
+        inputVariables.putValue("taskAttributes", Map.of("taskType", "allocateMultiTrack"));
         DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
 
         MatcherAssert.assertThat(dmnDecisionTableResult.getResultList(), is(List.of(
@@ -1450,6 +1446,45 @@ class CamundaTaskWaPermissionTest extends DmnDecisionTableBaseUnitTest {
             ),
             Map.of(
                 "name", "district-judge",
+                "value", "Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn",
+                "roleCategory", "JUDICIAL",
+                "autoAssignable", false
+            ),
+            Map.of(
+                "name", "leadership-judge",
+                "value", "Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn",
+                "roleCategory", "JUDICIAL",
+                "autoAssignable", false
+            )
+        )));
+    }
+
+    @Test
+    void given_allocateIntermediateTrack_taskType_when_evaluate_dmn_then_it_returns_expected_rule() {
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("taskAttributes", Map.of("taskType", "allocateIntermediateTrack"));
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        MatcherAssert.assertThat(dmnDecisionTableResult.getResultList(), is(List.of(
+            Map.of(
+                "name", "task-supervisor",
+                "autoAssignable", false,
+                "value", "Read,Manage,Cancel,Unassign,Assign"
+            ),
+            Map.of(
+                "name", "circuit-judge",
+                "value", "Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn",
+                "roleCategory", "JUDICIAL",
+                "autoAssignable", false
+            ),
+            Map.of(
+                "name", "district-judge",
+                "value", "Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn",
+                "roleCategory", "JUDICIAL",
+                "autoAssignable", false
+            ),
+            Map.of(
+                "name", "deputy-district-judge",
                 "value", "Read,Own,Claim,Unclaim,UnclaimAssign,CompleteOwn,CancelOwn",
                 "roleCategory", "JUDICIAL",
                 "autoAssignable", false


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-17685


### Change description ###
Gave deputy district judges access to allocateIntermediateTrack task.
<img width="1777" height="692" alt="Screenshot 2025-09-08 at 12 51 20" src="https://github.com/user-attachments/assets/85475e16-a471-4e25-a608-eae8f890eb05" />


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
